### PR TITLE
mcp4018t: *p_val instead of p_val[0]

### DIFF
--- a/app/drivers/mcp4018t.c
+++ b/app/drivers/mcp4018t.c
@@ -22,7 +22,7 @@ HAL_StatusTypeDef mcp4018t_set_value(uint8_t val)
 
 HAL_StatusTypeDef mcp4018t_get_value(uint8_t *p_val)
 {
-	return i2c_master_rx(MCP4018T_ADDRESS << 1, p_val, sizeof(p_val[0]), I2C_TIMEOUT);
+	return i2c_master_rx(MCP4018T_ADDRESS << 1, p_val, sizeof(*p_val), I2C_TIMEOUT);
 }
 
 HAL_StatusTypeDef mcp4018t_init(void)


### PR DESCRIPTION
Closes #12