### PR TITLE
Kb/uart dmafix

### DIFF
--- a/app/config/FreeRTOSConfig.h
+++ b/app/config/FreeRTOSConfig.h
@@ -104,6 +104,7 @@ extern uint32_t SystemCoreClock;
 #define configUSE_MUTEXES                        1
 #define configQUEUE_REGISTRY_SIZE                8
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION  1
+#define configCHECK_FOR_STACK_OVERFLOW           2
 
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES                    0

--- a/app/drivers/uart.h
+++ b/app/drivers/uart.h
@@ -5,10 +5,13 @@
 
 #define EUART_HAL_INIT					(EUART_BASE + 0)
 #define EUART_TX_SEMPH					(EUART_BASE + 1)
-#define EUART_TX						(EUART_BASE + 2)
-#define EUART_RX						(EUART_BASE + 3)
+#define EUART_RX_SEMPH					(EUART_BASE + 2)
+#define EUART_TX_TIMEOUT				(EUART_BASE + 3)
+#define EUART_RX_TIMEOUT				(EUART_BASE + 4)
+#define EUART_TX						(EUART_BASE + 5)
+#define EUART_RX						(EUART_BASE + 6)
 
 UART_HandleTypeDef *uart_get_handle(void);
-err_t uart_tx(UART_HandleTypeDef *p_handle, const uint8_t *p_buf, uint32_t size, uint32_t timeout_ms);
-err_t uart_rx(UART_HandleTypeDef *p_handle, uint8_t *p_buf, uint32_t size, uint32_t timeout_ms);
+err_t uart_tx(UART_HandleTypeDef *p_handle, const uint8_t *p_buf, uint32_t size, uint32_t timeout_ticks, bool blocking);
+err_t uart_rx(UART_HandleTypeDef *p_handle, uint8_t *p_buf, uint32_t size, uint32_t timeout_ticks);
 err_t uart_init(void);

--- a/app/errors.h
+++ b/app/errors.h
@@ -10,10 +10,13 @@ typedef uint32_t err_t;
 			for(;;); \
 	} while (0)
 
+#define HAL_ERROR_GET(x) (((x) >> 14) & 0x3)
+#define HAL_ERROR_SET(hal_status, err_to_return) (err_to_return | ((hal_status) << 14))
+
 #define HAL_ERR_CHECK(hal_status, err_to_return) \
 	do { \
 		if ((hal_status) != HAL_OK) \
-			return (err_to_return | ((hal_status) << 14)); \
+			return HAL_ERROR_SET(err_to_return, hal_status); \
 	} while (0)
 
 #define ERR_OK			(0)

--- a/app/freertos.c
+++ b/app/freertos.c
@@ -1,4 +1,5 @@
 #include "FreeRTOS.h"
+#include "task.h"
 
 #define IDLE_TASK_STACK_SIZE	configMINIMAL_STACK_SIZE
 #define TIMER_TASK_STACK_SIZE	configTIMER_TASK_STACK_DEPTH
@@ -21,6 +22,12 @@ void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer, Stack
 	*ppxTimerTaskTCBBuffer = &timer_task_tcb;
 	*ppxTimerTaskStackBuffer = &timer_task_stack[0];
 	*pulTimerTaskStackSize = TIMER_TASK_STACK_SIZE;
+}
+
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
+{
+	while(1)
+		;
 }
 
 __attribute__((weak))

--- a/app/main.c
+++ b/app/main.c
@@ -83,7 +83,7 @@ HAL_StatusTypeDef SystemClock_Config(void)
 
 int _write(int fd, const char *msg, int len)
 {
-	uart_tx(uart_get_handle(), (const uint8_t*)msg, len, 100);
+	uart_tx(uart_get_handle(), (const uint8_t*)msg, len, 100, true);
 	return len;
 }
 


### PR DESCRIPTION
Closes #43

I have tested this with a pretty nasty test case: Print multiple times async sequentially and then read from uart in the main task, at the same time print a character from the adc task for each sample we get. And it works, and doesn't lock up. 