### PR TITLE
freertos: Enable freertos-openocd integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ CFLAGS   += \
 
 LDFLAGS  := -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard -T$(LDSCRIPT)
 
-LIBS     := -Wl,--gc-sections --specs=nano.specs -lc -lnosys
+LIBS     := -Wl,--gc-sections --specs=nano.specs -lc -lnosys -Wl,--undefined=uxTopUsedPriority
 
 OBJS     := $(patsubst %.c,out/obj/%.o, $(filter %.c, $(SRCS))) $(patsubst %.s,out/obj/%.o, $(filter %.s, $(SRCS)))
 DEPS     := $(patsubst %.o,%.d,$(OBJS))
@@ -129,6 +129,7 @@ daplink:
 	@openocd \
 	-f interface/cmsis-dap.cfg \
 	-f target/stm32l4x.cfg \
+	-c "stm32l4x.cpu configure -rtos FreeRTOS" \
 	-c "init ; reset halt"
 .PHONY: daplink
 

--- a/app/freertos-openocd.c
+++ b/app/freertos-openocd.c
@@ -1,0 +1,21 @@
+/*
+ * https://raw.githubusercontent.com/arduino/OpenOCD/master/contrib/rtos-helpers/FreeRTOS-openocd.c
+ * Since at least FreeRTOS V7.5.3 uxTopUsedPriority is no longer
+ * present in the kernel, so it has to be supplied by other means for
+ * OpenOCD's threads awareness.
+ *
+ * Add this file to your project, and, if you're using --gc-sections,
+ * ``--undefined=uxTopUsedPriority'' (or
+ * ``-Wl,--undefined=uxTopUsedPriority'' when using gcc for final
+ * linking) to your LDFLAGS; same with all the other symbols you need.
+ */
+
+#include "FreeRTOS.h"
+
+#ifdef __GNUC__
+#define USED __attribute__((used))
+#else
+#define USED
+#endif
+
+const int USED uxTopUsedPriority = configMAX_PRIORITIES - 1;


### PR DESCRIPTION
Lets us use `info threads` etc.