### PR TITLE
i2c/uart: Use low speed to reduce noise

### DIFF
--- a/app/drivers/i2c.c
+++ b/app/drivers/i2c.c
@@ -16,7 +16,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef *p_handle)
 		gpio_config.Pin = GPIO_PIN_9 | GPIO_PIN_10;
 		gpio_config.Mode = GPIO_MODE_AF_OD;
 		gpio_config.Pull = GPIO_NOPULL;
-		gpio_config.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+		gpio_config.Speed = GPIO_SPEED_FREQ_LOW;
 		gpio_config.Alternate = GPIO_AF4_I2C1;
 		HAL_GPIO_Init(GPIOA, &gpio_config);
 

--- a/app/drivers/uart.c
+++ b/app/drivers/uart.c
@@ -46,7 +46,7 @@ void HAL_UART_MspInit(UART_HandleTypeDef *p_handle)
 		gpio_config.Pin = DUT_UART_TX_Pin|DUT_UART_RX_Pin;
 		gpio_config.Mode = GPIO_MODE_AF_PP;
 		gpio_config.Pull = GPIO_NOPULL;
-		gpio_config.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+		gpio_config.Speed = GPIO_SPEED_FREQ_LOW;
 		gpio_config.Alternate = GPIO_AF7_USART3;
 		HAL_GPIO_Init(GPIOB, &gpio_config);
 		


### PR DESCRIPTION
Using faster speed configuration leads to faster slew rates.
This will lead to high frequency noise that we don't want
unless we actually transfer data at very high speeds.
GPIO_SPEED_FREQ_LOW is specified to support up to 5 MHz.