### PR TITLE
Add dfu support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,10 @@ flash: out/$(TARGET)/app.elf
 	@echo -e "flash banks\nreset halt\nprogram $< verify\nreset run\nexit\n" | nc localhost 4444
 .PHONY: flash
 
+dfu: out/$(TARGET)/app.bin
+	# Uploads the binary to 0x08000000 and resets the target
+	@dfu-util -D $< -a 0 -R -v -s 0x08000000:leave
+
 ifneq ("$(MAKECMDGOALS)","clean")
 -include $(DEPS)
 endif

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ APP_SRCS := \
 	app/errorhandler.c \
 	app/freertos-openocd.c \
 	app/freertos.c \
+	app/persistent.c \
 	app/main.c \
 
 APP_INCLUDES := \

--- a/app/persistent.c
+++ b/app/persistent.c
@@ -1,0 +1,3 @@
+#include "persistent.h"
+
+struct persistent persistent_data __attribute__((section (".persistent")));

--- a/app/persistent.h
+++ b/app/persistent.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+struct persistent {
+	bool reboot_to_bootloader;
+};
+
+extern struct persistent persistent_data;

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -6,4 +6,5 @@
 
 void platform_delay_us(uint32_t delay_us);
 void platform_reset(void);
+void platform_reboot_to_dfu(void);
 err_t platform_init(void);

--- a/scripts/ld/STM32F072C8Tx_FLASH.ld
+++ b/scripts/ld/STM32F072C8Tx_FLASH.ld
@@ -118,11 +118,16 @@ SECTIONS
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 
+  .persistent(NOLOAD) :
+  {
+    __ram_start__ = .;
+    KEEP(*(.persistent*))
+  } >RAM
+
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data : 
   {
     . = ALIGN(4);
-    __ram_start__ = .;
     _sdata = .;        /* create a global symbol at data start */
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
@@ -159,8 +164,6 @@ SECTIONS
     . = ALIGN(8);
     __ram_end__ = .;
   } >RAM
-
-  
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/scripts/ld/STM32L433CCUx_FLASH.ld
+++ b/scripts/ld/STM32L433CCUx_FLASH.ld
@@ -132,11 +132,16 @@ SECTIONS
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
 
+  .persistent(NOLOAD) :
+  {
+    __ram_start__ = .;
+    KEEP(*(.persistent*))
+  } >RAM
+
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data : 
   {
     . = ALIGN(8);
-    __ram_start__ = .;
     _sdata = .;        /* create a global symbol at data start */
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
@@ -173,8 +178,6 @@ SECTIONS
     . = ALIGN(8);
     __ram_end__ = .;
   } >RAM
-
-  
 
   /* Remove information from the standard libraries */
   /DISCARD/ :


### PR DESCRIPTION
- Ability to run `make dfu` to flash using dfu-util
- Persistent RAM section
- API in the platform layer to reboot into dfu. Currently nothing triggers this, but it could be done through hid, cdc, gpio or whatever.