### PR TITLE
macros: Add macros.h

### DIFF
--- a/app/cdc_uart_bridge.c
+++ b/app/cdc_uart_bridge.c
@@ -9,7 +9,7 @@
 #include "platform/uart.h"
 #include "platform/usb/cdc.h"
 
-#define MODULE_NAME				CDC_UART_BRIDGE
+#define MODULE_NAME				cdc_uart_bridge
 #include "macros.h"
 
 #define RX_TASK_STACK_SIZE		128

--- a/app/drivers/max14662.c
+++ b/app/drivers/max14662.c
@@ -1,7 +1,7 @@
 #include "drivers/max14662.h"
 #include "platform/i2c.h"
 
-#define MODULE_NAME				MAX14662
+#define MODULE_NAME				max14662
 #include "macros.h"
 
 #define MAX14662_ADDRESS_0_0	0x4C

--- a/app/drivers/max14662.c
+++ b/app/drivers/max14662.c
@@ -1,6 +1,9 @@
 #include "drivers/max14662.h"
 #include "platform/i2c.h"
 
+#define MODULE_NAME				MAX14662
+#include "macros.h"
+
 #define MAX14662_ADDRESS_0_0	0x4C
 #define MAX14662_ADDRESS_0_1	0x4D
 #define MAX14662_ADDRESS_1_0	0x4E
@@ -16,7 +19,7 @@
 static struct {
 	bool initialized;
 	uint8_t state[NUM_OF_MAX14662_ADDRESSES];
-} self;
+} SELF;
 
 static uint8_t resolve_address(enum MAX14662_address address)
 {
@@ -59,51 +62,51 @@ err_t max14662_set_value(enum MAX14662_address address, uint8_t val)
 		val
 	};
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EMAX14662_NO_INIT;
 
-	if (self.state[address] == val)
+	if (SELF.state[address] == val)
 		return ERR_OK;
 
 	i2c_address = resolve_address(address);
 	r = i2c_master_tx(i2c_address << 1, data, sizeof(data), I2C_TIMEOUT_MS);
 	ERR_CHECK(r);
 
-	self.state[address] = val;
+	SELF.state[address] = val;
 
 	return r;
 }
 
 err_t max14662_set_bit(enum MAX14662_address address, enum MAX14662_bit bit, bool value)
 {
-	const uint8_t current_value = self.state[address];
+	const uint8_t current_value = SELF.state[address];
 	const bool masked_bit = !!(current_value & (1 << bit));
 	uint8_t new_value;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EMAX14662_NO_INIT;
 
 	if (masked_bit == value)
 		return ERR_OK;
 
 	if (value)
-		new_value = self.state[address] | (1 << bit);
+		new_value = SELF.state[address] | (1 << bit);
 	else
-		new_value = self.state[address] & (~(1 << bit));
+		new_value = SELF.state[address] & (~(1 << bit));
 	
 	return max14662_set_value(address, new_value);
 }
 
 uint8_t max14662_get_value_cached(enum MAX14662_address address)
 {
-	return self.state[address];
+	return SELF.state[address];
 }
 
 err_t max14662_get_value(enum MAX14662_address address, uint8_t *p_val)
 {
 	const uint8_t i2c_address = resolve_address(address);
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EMAX14662_NO_INIT;
 
 	return i2c_master_rx(i2c_address << 1, p_val, sizeof(*p_val), I2C_TIMEOUT_MS);
@@ -113,26 +116,26 @@ err_t max14662_init(enum MAX14662_address address)
 {
 	err_t r;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	r = max14662_set_and_verify(address, SELF_TEST_VALUE_1);
 	if (r != ERR_OK) {
-		self.initialized = false;
+		SELF.initialized = false;
 		return r;
 	}
 
 	r = max14662_set_and_verify(address, SELF_TEST_VALUE_2);
 	if (r != ERR_OK) {
-		self.initialized = false;
+		SELF.initialized = false;
 		return r;
 	}
 
 	r = max14662_set_value(address, DEFAULT_VALUE);
 	if (r != ERR_OK) {
-		self.initialized = false;
+		SELF.initialized = false;
 		return r;
 	}
 

--- a/app/drivers/mcp4018t.c
+++ b/app/drivers/mcp4018t.c
@@ -1,7 +1,10 @@
+#include <stdbool.h>
+
 #include "drivers/mcp4018t.h"
 #include "platform/i2c.h"
 
-#include <stdbool.h>
+#define MODULE_NAME			MCP4018T
+#include "macros.h"
 
 #define MCP4018T_ADDRESS	0x2F
 #define I2C_TIMEOUT_MS		100
@@ -12,17 +15,17 @@
 static struct {
 	bool initialized;
 	uint8_t value;
-} self;
+} SELF;
 
 err_t mcp4018t_set_value(uint8_t val)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EMCP4018T_NO_INIT;
 
 	if (val > MAX_VALUE)
 		return EMCP4018T_INVALID_ARG;
 
-	if (self.value == val)
+	if (SELF.value == val)
 		return ERR_OK;
 
 	return i2c_master_tx(MCP4018T_ADDRESS << 1, &val, sizeof(val), I2C_TIMEOUT_MS);
@@ -30,7 +33,7 @@ err_t mcp4018t_set_value(uint8_t val)
 
 err_t mcp4018t_get_value(uint8_t *p_val)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EMCP4018T_NO_INIT;
 
 	if (!p_val)
@@ -44,35 +47,35 @@ err_t mcp4018t_init(void)
 	uint8_t value;
 	err_t r;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	r = mcp4018t_set_value(SELF_TEST_VALUE);
 	if (r != ERR_OK) {
-		self.initialized = false;
+		SELF.initialized = false;
 		return r;
 	}
 
 	r = mcp4018t_get_value(&value);
 	if (r != ERR_OK) {
-		self.initialized = false;
+		SELF.initialized = false;
 		return r;
 	}
 
 	if (value != SELF_TEST_VALUE) {
-		self.initialized = false;
+		SELF.initialized = false;
 		return EMCP4018T_INVALID_RESPONSE;
 	}
 
 	r = mcp4018t_set_value(DEFAULT_VALUE);
 	if (r != ERR_OK) {
-		self.initialized = false;
+		SELF.initialized = false;
 		return r;
 	}
 
-	self.value = DEFAULT_VALUE;
+	SELF.value = DEFAULT_VALUE;
 
 	return ERR_OK;
 }

--- a/app/drivers/mcp4018t.c
+++ b/app/drivers/mcp4018t.c
@@ -3,7 +3,7 @@
 #include "drivers/mcp4018t.h"
 #include "platform/i2c.h"
 
-#define MODULE_NAME			MCP4018T
+#define MODULE_NAME			mcp4018t
 #include "macros.h"
 
 #define MCP4018T_ADDRESS	0x2F

--- a/app/macros.h
+++ b/app/macros.h
@@ -4,9 +4,6 @@
 #error You must define MODULE_NAME before including this file
 #endif
 
-//#undef MODULE_NAME
-//#define MODULE_NAME Trololo_lo
-
 #define cat(x, y) x ## y
 #define cat2(x, y) cat(x, y)
 #define SELF cat2(MODULE_NAME, _self)

--- a/app/macros.h
+++ b/app/macros.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifndef MODULE_NAME
+#error You must define MODULE_NAME before including this file
+#endif
+
+//#undef MODULE_NAME
+//#define MODULE_NAME Trololo_lo
+
+#define cat(x, y) x ## y
+#define cat2(x, y) cat(x, y)
+#define SELF cat2(MODULE_NAME, _self)

--- a/app/power.c
+++ b/app/power.c
@@ -7,7 +7,7 @@
 #include "platform/gpio.h"
 #include "power.h"
 
-#define MODULE_NAME				POWER
+#define MODULE_NAME				power
 #include "macros.h"
 
 #define POWER_TASK_STACK_SIZE	128

--- a/app/power.c
+++ b/app/power.c
@@ -7,6 +7,9 @@
 #include "platform/gpio.h"
 #include "power.h"
 
+#define MODULE_NAME				POWER
+#include "macros.h"
+
 #define POWER_TASK_STACK_SIZE	128
 #define POWER_TASK_NAME			"Power"
 #define POWER_TASK_PRIORITY		1
@@ -34,7 +37,7 @@ static struct {
 	/* TODO: Add support to configure these calibration values */
 	uint32_t calib_min_mv;
 	uint32_t calib_max_mv;
-} self;
+} SELF;
 
 /*
 TODO: Uncomment when we need them
@@ -64,13 +67,13 @@ static float calib_shunt_11 = 512.2f;
 static void shunt1_set_enabled(bool enabled)
 {
 	gpio_write(SHUNT1_EN_GPIO_Port, SHUNT1_EN_Pin, !enabled);
-	self.shunt1_enabled = enabled;
+	SELF.shunt1_enabled = enabled;
 }
 
 static void shunt2_set_enabled(bool enabled)
 {
 	gpio_write(SHUNT2_EN_GPIO_Port, SHUNT2_EN_Pin, !enabled);
-	self.shunt2_enabled = enabled;
+	SELF.shunt2_enabled = enabled;
 }
 
 static void power_task(void *p_arg)
@@ -78,7 +81,7 @@ static void power_task(void *p_arg)
 	uint16_t adc_values[NUM_OF_ADC_CHANNELS];
 
 	for (;;) {
-		xQueueReceive(self.queue_handle, adc_values, portMAX_DELAY);
+		xQueueReceive(SELF.queue_handle, adc_values, portMAX_DELAY);
 
 		/* TODO: Do stuff with the values */
 	}
@@ -88,25 +91,25 @@ static void adc_conversion_ready_handler(const uint16_t adc_values[NUM_OF_ADC_CH
 {
 	BaseType_t higher_priority_task_woken = pdFALSE;
 
-	xQueueSendFromISR(self.queue_handle, adc_values, &higher_priority_task_woken);
+	xQueueSendFromISR(SELF.queue_handle, adc_values, &higher_priority_task_woken);
 	portYIELD_FROM_ISR(higher_priority_task_woken);
 }
 
 void power_dut_set_enabled(bool enabled)
 {
 	gpio_write(DUT_VDD_EN_GPIO_Port, DUT_VDD_EN_Pin, !enabled);
-	self.dut_vdd_enabled = enabled;
+	SELF.dut_vdd_enabled = enabled;
 }
 
 err_t power_dut_get_enabled(bool *p_enabled)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EPOWER_NO_INIT;
 
 	if (!p_enabled)
 		return EPOWER_INVALID_ARG;
 
-	*p_enabled = self.dut_vdd_enabled;
+	*p_enabled = SELF.dut_vdd_enabled;
 
 	return ERR_OK;
 }
@@ -115,34 +118,34 @@ err_t power_dut_ldo_set(uint32_t millivolt)
 {
 	err_t r;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EPOWER_NO_INIT;
 
-	if (millivolt < self.calib_min_mv)
-		millivolt = self.calib_min_mv;
-	else if(millivolt > self.calib_max_mv)
-		millivolt = self.calib_max_mv;
+	if (millivolt < SELF.calib_min_mv)
+		millivolt = SELF.calib_min_mv;
+	else if(millivolt > SELF.calib_max_mv)
+		millivolt = SELF.calib_max_mv;
 
-	const float factor = (self.calib_max_mv - ((float)millivolt)) / (self.calib_max_mv - self.calib_min_mv);
+	const float factor = (SELF.calib_max_mv - ((float)millivolt)) / (SELF.calib_max_mv - SELF.calib_min_mv);
 	const uint8_t value = (uint8_t) (factor * 127 - 0.5f);
 
 	r = mcp4018t_set_value(value);
 	ERR_CHECK(r);
 
-	self.ldo_voltage = millivolt;
+	SELF.ldo_voltage = millivolt;
 
 	return r;
 }
 
 err_t power_dut_ldo_get(uint32_t *p_millivolt)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EPOWER_NO_INIT;
 
 	if (!p_millivolt)
 		return EPOWER_INVALID_ARG;
 
-	*p_millivolt = self.ldo_voltage;
+	*p_millivolt = SELF.ldo_voltage;
 
 	return ERR_OK;
 }
@@ -151,22 +154,22 @@ err_t power_init(void)
 {
 	err_t r;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.task_handle = xTaskCreateStatic(
+	SELF.task_handle = xTaskCreateStatic(
 		power_task,
 		POWER_TASK_NAME,
 		POWER_TASK_STACK_SIZE,
 		NULL,
 		POWER_TASK_PRIORITY,
-		&self.task_stack[0],
-		&self.task_tcb);
-	if (self.task_handle == NULL)
+		&SELF.task_stack[0],
+		&SELF.task_tcb);
+	if (SELF.task_handle == NULL)
 		return EPOWER_TASK_CREATE;
 
-	self.queue_handle = xQueueCreateStatic(QUEUE_LENGTH, QUEUE_ITEM_SIZE, self.queue_storage, &self.queue);
-	if (self.queue_handle == NULL)
+	SELF.queue_handle = xQueueCreateStatic(QUEUE_LENGTH, QUEUE_ITEM_SIZE, SELF.queue_storage, &SELF.queue);
+	if (SELF.queue_handle == NULL)
 		return EPOWER_QUEUE_CREATE;
 
 	adc_set_callback(adc_conversion_ready_handler);
@@ -177,15 +180,15 @@ err_t power_init(void)
 	shunt1_set_enabled(true);
 	shunt2_set_enabled(true);
 
-	self.calib_min_mv = DEFAULT_CALIB_MIN_MV;
-	self.calib_max_mv = DEFAULT_CALIB_MAX_MV;
+	SELF.calib_min_mv = DEFAULT_CALIB_MIN_MV;
+	SELF.calib_max_mv = DEFAULT_CALIB_MAX_MV;
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	/* TODO: Might want to keep this in persistent ram and/or flash so we can
 	 * resume with the previous values after a cold boot.
 	 */
-	power_dut_ldo_set(self.calib_min_mv);
+	power_dut_ldo_set(SELF.calib_min_mv);
 
 	return ERR_OK;
 }

--- a/platforms/stm32f0xx/pcd.c
+++ b/platforms/stm32f0xx/pcd.c
@@ -2,13 +2,16 @@
 #include <string.h>
 
 #include "pcd.h"
-#include "usb/ctlreq.h"
-#include "usb/core.h"
 #include "stm32f0xx_hal.h"
+#include "usb/core.h"
+#include "usb/ctlreq.h"
+
+#define MODULE_NAME			PCD
+#include "macros.h"
 
 static struct {
 	USBD_HandleTypeDef *p_usbd;
-} self;
+} SELF;
 
 extern HAL_StatusTypeDef SystemClock_Config(void);
 
@@ -37,30 +40,30 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *p_pcd)
 {
 	uint8_t *p_setup = (uint8_t *)p_pcd->Setup;
 
-	memcpy(&self.p_usbd->request.bmRequest, p_setup, 1);
-	self.p_usbd->request.bRequest  = *(uint8_t *)(p_setup +  1);
-	self.p_usbd->request.wValue    =     SWAPBYTE(p_setup +  2);
-	self.p_usbd->request.wIndex    =     SWAPBYTE(p_setup +  4);
-	self.p_usbd->request.wLength   =     SWAPBYTE(p_setup +  6);
+	memcpy(&SELF.p_usbd->request.bmRequest, p_setup, 1);
+	SELF.p_usbd->request.bRequest  = *(uint8_t *)(p_setup +  1);
+	SELF.p_usbd->request.wValue    =     SWAPBYTE(p_setup +  2);
+	SELF.p_usbd->request.wIndex    =     SWAPBYTE(p_setup +  4);
+	SELF.p_usbd->request.wLength   =     SWAPBYTE(p_setup +  6);
 
-	self.p_usbd->ep0_state = USBD_EP0_SETUP;
-	self.p_usbd->ep0_data_len = self.p_usbd->request.wLength;
+	SELF.p_usbd->ep0_state = USBD_EP0_SETUP;
+	SELF.p_usbd->ep0_data_len = SELF.p_usbd->request.wLength;
 
-	switch (self.p_usbd->request.bmRequest.recipient) {
+	switch (SELF.p_usbd->request.bmRequest.recipient) {
 	case USB_REQ_RECIPIENT_DEVICE:
-		USBD_StdDevReq(self.p_usbd, p_pcd, &self.p_usbd->request);
+		USBD_StdDevReq(SELF.p_usbd, p_pcd, &SELF.p_usbd->request);
 		break;
 
 	case USB_REQ_RECIPIENT_INTERFACE:
-		USBD_StdItfReq(self.p_usbd, p_pcd, &self.p_usbd->request);
+		USBD_StdItfReq(SELF.p_usbd, p_pcd, &SELF.p_usbd->request);
 		break;
 
 	case USB_REQ_RECIPIENT_ENDPOINT:
-		USBD_StdEPReq(self.p_usbd, p_pcd, &self.p_usbd->request);
+		USBD_StdEPReq(SELF.p_usbd, p_pcd, &SELF.p_usbd->request);
 		break;
 
 	default:
-		HAL_PCD_EP_SetStall(p_pcd, *(uint8_t*)(&self.p_usbd->request.bmRequest) & 0x80);
+		HAL_PCD_EP_SetStall(p_pcd, *(uint8_t*)(&SELF.p_usbd->request.bmRequest) & 0x80);
 		break;
 	}
 }
@@ -68,27 +71,27 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *p_pcd)
 void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *p_pcd, uint8_t epnum)
 {
 	if (epnum == 0x00) {
-		USBD_EndpointTypeDef *p_ep = &self.p_usbd->ep_out[0];
+		USBD_EndpointTypeDef *p_ep = &SELF.p_usbd->ep_out[0];
 		uint8_t *p_data = p_pcd->OUT_ep[epnum].xfer_buff;
 
-		if (self.p_usbd->ep0_state == USBD_EP0_DATA_OUT) {
+		if (SELF.p_usbd->ep0_state == USBD_EP0_DATA_OUT) {
 			if (p_ep->rem_length > p_ep->maxpacket) {
 				p_ep->rem_length -= p_ep->maxpacket;
 
 				HAL_PCD_EP_Receive(p_pcd, 0x00, p_data, MIN(p_ep->rem_length, p_ep->maxpacket));
 			} else {
 				for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-					if ((self.p_usbd->pClasses[i]->EP0_RxReady != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-						self.p_usbd->pClasses[i]->EP0_RxReady(self.p_usbd);
+					if ((SELF.p_usbd->pClasses[i]->EP0_RxReady != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+						SELF.p_usbd->pClasses[i]->EP0_RxReady(SELF.p_usbd);
 				}
 
-				USBD_CtlSendStatus(self.p_usbd);
+				USBD_CtlSendStatus(SELF.p_usbd);
 			}
 		}
 	} else {
 		for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-			if ((self.p_usbd->pClasses[i]->DataOut != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-				self.p_usbd->pClasses[i]->DataOut(self.p_usbd, epnum);
+			if ((SELF.p_usbd->pClasses[i]->DataOut != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+				SELF.p_usbd->pClasses[i]->DataOut(SELF.p_usbd, epnum);
 		}
 	}
 }
@@ -99,9 +102,9 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *p_pcd, uint8_t epnum)
 	USBD_EndpointTypeDef *p_ep;
 
 	if (epnum == 0x00) {
-		p_ep = &self.p_usbd->ep_in[0];
+		p_ep = &SELF.p_usbd->ep_in[0];
 
-		if ( self.p_usbd->ep0_state == USBD_EP0_DATA_IN) {
+		if ( SELF.p_usbd->ep0_state == USBD_EP0_DATA_IN) {
 			if (p_ep->rem_length > p_ep->maxpacket) {
 				p_ep->rem_length -=  p_ep->maxpacket;
 
@@ -110,68 +113,68 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *p_pcd, uint8_t epnum)
 				/* Prepare endpoint for premature end of transfer */
 				HAL_PCD_EP_Receive(p_pcd, 0, NULL, 0);
 			} else { /* last packet is MPS multiple, so send ZLP packet */
-				if ((p_ep->total_length % p_ep->maxpacket == 0) && (p_ep->total_length >= p_ep->maxpacket) && (p_ep->total_length < self.p_usbd->ep0_data_len )) {
+				if ((p_ep->total_length % p_ep->maxpacket == 0) && (p_ep->total_length >= p_ep->maxpacket) && (p_ep->total_length < SELF.p_usbd->ep0_data_len )) {
 					HAL_PCD_EP_Transmit(p_pcd, 0x00, NULL, 0);
-					self.p_usbd->ep0_data_len = 0;
+					SELF.p_usbd->ep0_data_len = 0;
 
 					/* Prepare endpoint for premature end of transfer */
 					HAL_PCD_EP_Receive(p_pcd, 0, NULL, 0);
 				} else {
 					for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-						if ((self.p_usbd->pClasses[i]->EP0_TxSent != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-							self.p_usbd->pClasses[i]->EP0_TxSent(self.p_usbd);
+						if ((SELF.p_usbd->pClasses[i]->EP0_TxSent != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+							SELF.p_usbd->pClasses[i]->EP0_TxSent(SELF.p_usbd);
 					}
 
-					self.p_usbd->ep0_state = USBD_EP0_STATUS_OUT;
+					SELF.p_usbd->ep0_state = USBD_EP0_STATUS_OUT;
 					HAL_PCD_EP_Receive(p_pcd, 0x00, NULL, 0);
 				}
 			}
 		}
 	} else {
 		for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-			if ((self.p_usbd->pClasses[i]->DataIn != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-				self.p_usbd->pClasses[i]->DataIn(self.p_usbd, epnum | 0x80);
+			if ((SELF.p_usbd->pClasses[i]->DataIn != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+				SELF.p_usbd->pClasses[i]->DataIn(SELF.p_usbd, epnum | 0x80);
 		}
 	}
 }
 
 void HAL_PCD_SOFCallback(PCD_HandleTypeDef *p_pcd)
 {
-	if (self.p_usbd->dev_state != USBD_STATE_CONFIGURED)
+	if (SELF.p_usbd->dev_state != USBD_STATE_CONFIGURED)
 		return;
 
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-		if (self.p_usbd->pClasses[i]->SOF != NULL)
-			self.p_usbd->pClasses[i]->SOF(self.p_usbd);
+		if (SELF.p_usbd->pClasses[i]->SOF != NULL)
+			SELF.p_usbd->pClasses[i]->SOF(SELF.p_usbd);
 	}
 }
 
 void HAL_PCD_ResetCallback(PCD_HandleTypeDef *p_pcd)
 {
-	self.p_usbd->dev_speed = USBD_SPEED_FULL;
+	SELF.p_usbd->dev_speed = USBD_SPEED_FULL;
 
 	/* Open EP0 OUT */
 	HAL_PCD_EP_Open(p_pcd, 0x00, USB_MAX_EP0_SIZE, USBD_EP_TYPE_CTRL);
 
-	self.p_usbd->ep_out[0].maxpacket = USB_MAX_EP0_SIZE;
+	SELF.p_usbd->ep_out[0].maxpacket = USB_MAX_EP0_SIZE;
 
 	/* Open EP0 IN */
 	HAL_PCD_EP_Open(p_pcd, 0x80, USB_MAX_EP0_SIZE, USBD_EP_TYPE_CTRL);
 
-	self.p_usbd->ep_in[0].maxpacket = USB_MAX_EP0_SIZE;
+	SELF.p_usbd->ep_in[0].maxpacket = USB_MAX_EP0_SIZE;
 
 	/* Upon Reset call user call back */
-	self.p_usbd->dev_state = USBD_STATE_DEFAULT;
+	SELF.p_usbd->dev_state = USBD_STATE_DEFAULT;
 
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i)
-		self.p_usbd->pClasses[i]->DeInit(self.p_usbd, self.p_usbd->dev_config);
+		SELF.p_usbd->pClasses[i]->DeInit(SELF.p_usbd, SELF.p_usbd->dev_config);
 }
 
 void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *p_pcd)
 {
 	/* Inform USB library that core enters in suspend Mode. */
-	self.p_usbd->dev_old_state = self.p_usbd->dev_state;
-	self.p_usbd->dev_state = USBD_STATE_SUSPENDED;
+	SELF.p_usbd->dev_old_state = SELF.p_usbd->dev_state;
+	SELF.p_usbd->dev_state = USBD_STATE_SUSPENDED;
 
 	/* Enter in STOP mode. */
 	if (p_pcd->Init.low_power_enable) {
@@ -188,21 +191,21 @@ void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *p_pcd)
 		SystemClock_Config();
 	}
 
-	self.p_usbd->dev_state = self.p_usbd->dev_old_state;
+	SELF.p_usbd->dev_state = SELF.p_usbd->dev_old_state;
 }
 
 void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *p_pcd)
 {
 	/* Free Class Resources */
-	self.p_usbd->dev_state = USBD_STATE_DEFAULT;
+	SELF.p_usbd->dev_state = USBD_STATE_DEFAULT;
 
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i)
-		self.p_usbd->pClasses[i]->DeInit(self.p_usbd, self.p_usbd->dev_config);
+		SELF.p_usbd->pClasses[i]->DeInit(SELF.p_usbd, SELF.p_usbd->dev_config);
 }
 
 err_t pcd_init(USBD_HandleTypeDef *p_usbd)
 {
-	self.p_usbd = p_usbd;
+	SELF.p_usbd = p_usbd;
 
 	return ERR_OK;
 }

--- a/platforms/stm32f0xx/pcd.c
+++ b/platforms/stm32f0xx/pcd.c
@@ -6,7 +6,7 @@
 #include "usb/core.h"
 #include "usb/ctlreq.h"
 
-#define MODULE_NAME			PCD
+#define MODULE_NAME			pcd
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32f0xx/uart.c
+++ b/platforms/stm32f0xx/uart.c
@@ -11,7 +11,7 @@
 #include "stm32f0xx_hal.h"
 #include "stm32f0xx_ll_dma.h"
 
-#define MODULE_NAME				UART
+#define MODULE_NAME				uart
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32f0xx/uart.c
+++ b/platforms/stm32f0xx/uart.c
@@ -11,6 +11,9 @@
 #include "stm32f0xx_hal.h"
 #include "stm32f0xx_ll_dma.h"
 
+#define MODULE_NAME				UART
+#include "macros.h"
+
 static struct {
 	DMA_HandleTypeDef hdma_usart1_tx;
 	DMA_HandleTypeDef hdma_usart1_rx;
@@ -31,7 +34,7 @@ static struct {
 
 	bool enabled;
 	bool initialized;
-} self;
+} SELF;
 
 void HAL_UART_MspInit(UART_HandleTypeDef *p_handle)
 {
@@ -49,34 +52,34 @@ void HAL_UART_MspInit(UART_HandleTypeDef *p_handle)
 		gpio_config.Alternate = GPIO_AF0_USART1;
 		HAL_GPIO_Init(GPIOB, &gpio_config);
 		
-		self.hdma_usart1_tx.Instance = DMA1_Channel2;
-		self.hdma_usart1_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-		self.hdma_usart1_tx.Init.PeriphInc = DMA_PINC_DISABLE;
-		self.hdma_usart1_tx.Init.MemInc = DMA_MINC_ENABLE;
-		self.hdma_usart1_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-		self.hdma_usart1_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-		self.hdma_usart1_tx.Init.Mode = DMA_NORMAL;
-		self.hdma_usart1_tx.Init.Priority = DMA_PRIORITY_LOW;
-		status = HAL_DMA_Init(&self.hdma_usart1_tx);
+		SELF.hdma_usart1_tx.Instance = DMA1_Channel2;
+		SELF.hdma_usart1_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+		SELF.hdma_usart1_tx.Init.PeriphInc = DMA_PINC_DISABLE;
+		SELF.hdma_usart1_tx.Init.MemInc = DMA_MINC_ENABLE;
+		SELF.hdma_usart1_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+		SELF.hdma_usart1_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+		SELF.hdma_usart1_tx.Init.Mode = DMA_NORMAL;
+		SELF.hdma_usart1_tx.Init.Priority = DMA_PRIORITY_LOW;
+		status = HAL_DMA_Init(&SELF.hdma_usart1_tx);
 		if (status != HAL_OK)
 			for (;;);
 
-		__HAL_LINKDMA(p_handle, hdmatx, self.hdma_usart1_tx);
+		__HAL_LINKDMA(p_handle, hdmatx, SELF.hdma_usart1_tx);
 
 		/* USART1_RX Init */
-		self.hdma_usart1_rx.Instance = DMA1_Channel3;
-		self.hdma_usart1_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-		self.hdma_usart1_rx.Init.PeriphInc = DMA_PINC_DISABLE;
-		self.hdma_usart1_rx.Init.MemInc = DMA_MINC_ENABLE;
-		self.hdma_usart1_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-		self.hdma_usart1_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-		self.hdma_usart1_rx.Init.Mode = DMA_NORMAL;
-		self.hdma_usart1_rx.Init.Priority = DMA_PRIORITY_LOW;
-		status = HAL_DMA_Init(&self.hdma_usart1_rx);
+		SELF.hdma_usart1_rx.Instance = DMA1_Channel3;
+		SELF.hdma_usart1_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
+		SELF.hdma_usart1_rx.Init.PeriphInc = DMA_PINC_DISABLE;
+		SELF.hdma_usart1_rx.Init.MemInc = DMA_MINC_ENABLE;
+		SELF.hdma_usart1_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+		SELF.hdma_usart1_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+		SELF.hdma_usart1_rx.Init.Mode = DMA_NORMAL;
+		SELF.hdma_usart1_rx.Init.Priority = DMA_PRIORITY_LOW;
+		status = HAL_DMA_Init(&SELF.hdma_usart1_rx);
 		if (status != HAL_OK)
 			for (;;);
 
-		__HAL_LINKDMA(p_handle, hdmarx, self.hdma_usart1_rx);
+		__HAL_LINKDMA(p_handle, hdmarx, SELF.hdma_usart1_rx);
 
 		/* USART1 interrupt Init */
 		HAL_NVIC_SetPriority(USART1_IRQn, 3, 0);
@@ -109,7 +112,7 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *p_uart)
 {
 	static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	xSemaphoreGiveFromISR(self.tx_done_semaphore, &xHigherPriorityTaskWoken);
+	xSemaphoreGiveFromISR(SELF.tx_done_semaphore, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
@@ -117,35 +120,35 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *p_uart)
 {
 	static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	self.rx_item.len = USB_FS_MAX_PACKET_SIZE;
-	xQueueSendFromISR(self.rx_queue_handle, &self.rx_item, &xHigherPriorityTaskWoken);
+	SELF.rx_item.len = USB_FS_MAX_PACKET_SIZE;
+	xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_item, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-	HAL_UART_Receive_DMA(&self.uart_handle, (uint8_t*) self.rx_item.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_UART_Receive_DMA(&SELF.uart_handle, (uint8_t*) SELF.rx_item.data, USB_FS_MAX_PACKET_SIZE);
 }
 
 void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *p_uart)
 {
 	static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	self.rx_item.len = USB_FS_MAX_PACKET_SIZE - LL_DMA_GetDataLength(DMA1, LL_DMA_CHANNEL_3);
+	SELF.rx_item.len = USB_FS_MAX_PACKET_SIZE - LL_DMA_GetDataLength(DMA1, LL_DMA_CHANNEL_3);
 
-	if (self.rx_item.len) {
-		xQueueSendFromISR(self.rx_queue_handle, &self.rx_item, &xHigherPriorityTaskWoken);
+	if (SELF.rx_item.len) {
+		xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_item, &xHigherPriorityTaskWoken);
 		portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 	}
 
-	HAL_UART_Receive_DMA(&self.uart_handle, (uint8_t*) self.rx_item.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_UART_Receive_DMA(&SELF.uart_handle, (uint8_t*) SELF.rx_item.data, USB_FS_MAX_PACKET_SIZE);
 }
 
 void USART1_IRQHandler(void)
 {
-	HAL_UART_IRQHandler(&self.uart_handle);
+	HAL_UART_IRQHandler(&SELF.uart_handle);
 }
 
 void DMA1_Channel2_3_IRQHandler(void)
 {
-	HAL_DMA_IRQHandler(&self.hdma_usart1_rx);
-	HAL_DMA_IRQHandler(&self.hdma_usart1_tx);
+	HAL_DMA_IRQHandler(&SELF.hdma_usart1_rx);
+	HAL_DMA_IRQHandler(&SELF.hdma_usart1_tx);
 }
 
 err_t uart_tx(const uint8_t *p_buf, uint32_t size, uint32_t timeout_ticks, bool blocking)
@@ -153,37 +156,37 @@ err_t uart_tx(const uint8_t *p_buf, uint32_t size, uint32_t timeout_ticks, bool 
 	HAL_StatusTypeDef status;
 	err_t r = ERR_OK;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
-	if (xSemaphoreTake(self.tx_busy_semaphore, timeout_ticks) == pdFALSE)
+	if (xSemaphoreTake(SELF.tx_busy_semaphore, timeout_ticks) == pdFALSE)
 		return EUART_TX_SEMPH;
 
-	if (xSemaphoreTake(self.tx_done_semaphore, timeout_ticks) == pdFALSE) {
+	if (xSemaphoreTake(SELF.tx_done_semaphore, timeout_ticks) == pdFALSE) {
 		r = EUART_TX_SEMPH;
 		goto out;
 	}
 
 	/* Ugly const-to-non-const cast because the HAL is annoying. */
-	status = HAL_UART_Transmit_DMA(&self.uart_handle, (uint8_t*) p_buf, size);
+	status = HAL_UART_Transmit_DMA(&SELF.uart_handle, (uint8_t*) p_buf, size);
 	if (status != HAL_OK) {
 		r = HAL_ERROR_SET(status, EUART_TX);
 		goto out;
 	}
 
 	if (blocking) {
-		if (xSemaphoreTake(self.tx_done_semaphore, timeout_ticks) == pdFALSE) {
+		if (xSemaphoreTake(SELF.tx_done_semaphore, timeout_ticks) == pdFALSE) {
 			r = EUART_TX_TIMEOUT;
 			goto out;
 		}
-		xSemaphoreGive(self.tx_done_semaphore);
+		xSemaphoreGive(SELF.tx_done_semaphore);
 	}
 
 out:
-	xSemaphoreGive(self.tx_busy_semaphore);
+	xSemaphoreGive(SELF.tx_busy_semaphore);
 	return r;
 }
 
@@ -191,14 +194,14 @@ err_t uart_start_rx(QueueHandle_t queue)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
-	self.rx_queue_handle = queue;
-	status = HAL_UART_Receive_DMA(&self.uart_handle, (uint8_t*) self.rx_item.data, USB_FS_MAX_PACKET_SIZE);
+	SELF.rx_queue_handle = queue;
+	status = HAL_UART_Receive_DMA(&SELF.uart_handle, (uint8_t*) SELF.rx_item.data, USB_FS_MAX_PACKET_SIZE);
 	HAL_ERR_CHECK(status, EUART_RX);
 
 	return ERR_OK;
@@ -208,14 +211,14 @@ err_t uart_flush_rx(void)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
 	/* HAL_UART_AbortReceiveCpltCallback restarts DMA */
-	status = HAL_UART_AbortReceive_IT(&self.uart_handle);
+	status = HAL_UART_AbortReceive_IT(&SELF.uart_handle);
 	HAL_ERR_CHECK(status, EUART_FLUSH_RX);
 
 	return ERR_OK;
@@ -283,17 +286,17 @@ err_t uart_config_set(const struct uart_line_coding * const p_config)
 	HAL_StatusTypeDef status;
 	err_t r;
 	
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
 	r = parse_config(&hal_config, p_config);
 	ERR_CHECK(r);
 
-	self.uart_handle.Init = hal_config;
-	status = UART_SetConfig(&self.uart_handle);
+	SELF.uart_handle.Init = hal_config;
+	status = UART_SetConfig(&SELF.uart_handle);
 	HAL_ERR_CHECK(status, EUART_HAL_INIT);
 
 	return ERR_OK;
@@ -303,10 +306,10 @@ err_t uart_enable(void)
 {
 	err_t r = ERR_OK;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 	
-	if (self.enabled)
+	if (SELF.enabled)
 		return ERR_OK;
 
 #if (FEAT_DUT_SWITCH == 1)
@@ -317,7 +320,7 @@ err_t uart_enable(void)
 	ERR_CHECK(r);
 #endif
 
-	self.enabled = true;
+	SELF.enabled = true;
 
 	return r;
 }
@@ -328,10 +331,10 @@ err_t uart_disable(void)
 	err_t r;
 #endif
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return ERR_OK;
 
 #if (FEAT_DUT_SWITCH == 1)
@@ -342,7 +345,7 @@ err_t uart_disable(void)
 	ERR_CHECK(r);
 #endif
 
-	self.enabled = false;
+	SELF.enabled = false;
 
 	return ERR_OK;
 }
@@ -351,31 +354,31 @@ err_t uart_init(void)
 {
 	HAL_StatusTypeDef status;
 
-	self.uart_handle.Instance = USART1;
-	self.uart_handle.Init.BaudRate = 115200;
-	self.uart_handle.Init.WordLength = UART_WORDLENGTH_8B;
-	self.uart_handle.Init.StopBits = UART_STOPBITS_1;
-	self.uart_handle.Init.Parity = UART_PARITY_NONE;
-	self.uart_handle.Init.Mode = UART_MODE_TX_RX;
-	self.uart_handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-	self.uart_handle.Init.OverSampling = UART_OVERSAMPLING_16;
-	self.uart_handle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
-	self.uart_handle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
+	SELF.uart_handle.Instance = USART1;
+	SELF.uart_handle.Init.BaudRate = 115200;
+	SELF.uart_handle.Init.WordLength = UART_WORDLENGTH_8B;
+	SELF.uart_handle.Init.StopBits = UART_STOPBITS_1;
+	SELF.uart_handle.Init.Parity = UART_PARITY_NONE;
+	SELF.uart_handle.Init.Mode = UART_MODE_TX_RX;
+	SELF.uart_handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+	SELF.uart_handle.Init.OverSampling = UART_OVERSAMPLING_16;
+	SELF.uart_handle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+	SELF.uart_handle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
 
-	status = HAL_UART_Init(&self.uart_handle);
+	status = HAL_UART_Init(&SELF.uart_handle);
 	HAL_ERR_CHECK(status, EUART_HAL_INIT);
 
-	self.tx_busy_semaphore = xSemaphoreCreateMutexStatic(&self.tx_busy_semaphore_buffer);
-	xSemaphoreGive(self.tx_busy_semaphore);
-	self.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.tx_done_semaphore_buffer);
-	xSemaphoreGive(self.tx_done_semaphore);
+	SELF.tx_busy_semaphore = xSemaphoreCreateMutexStatic(&SELF.tx_busy_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_busy_semaphore);
+	SELF.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.tx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_done_semaphore);
 
-	self.rx_busy_semaphore = xSemaphoreCreateMutexStatic(&self.rx_busy_semaphore_buffer);
-	xSemaphoreGive(self.rx_busy_semaphore);
-	self.rx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.rx_done_semaphore_buffer);
-	xSemaphoreGive(self.rx_done_semaphore);
+	SELF.rx_busy_semaphore = xSemaphoreCreateMutexStatic(&SELF.rx_busy_semaphore_buffer);
+	xSemaphoreGive(SELF.rx_busy_semaphore);
+	SELF.rx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.rx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.rx_done_semaphore);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32f0xx/usb.c
+++ b/platforms/stm32f0xx/usb.c
@@ -5,17 +5,20 @@
 #include "platform/usb/cdc.h"
 #include "platform/usb/hid.h"
 #include "platform/usb/usb.h"
+#include "usb/cdc_internal.h"
 #include "usb/core.h"
 #include "usb/ctlreq.h"
-#include "usb/cdc_internal.h"
 #include "usb/hid_internal.h"
+
+#define MODULE_NAME				STM32F0XX_USB
+#include "macros.h"
 
 static struct {
 	bool initialized;
 	USBD_HandleTypeDef usbd_handle;
 	PCD_HandleTypeDef pcd_handle;
 	char usb_serialnumber_string[17];
-} self;
+} SELF;
 
 static uint8_t *usb_desc_device(USBD_SpeedTypeDef speed, uint16_t *p_len);
 static uint8_t *usb_desc_langid(USBD_SpeedTypeDef speed, uint16_t *p_len);
@@ -306,7 +309,7 @@ static uint8_t *usb_desc_usr_str(USBD_HandleTypeDef *p_dev, uint8_t idx, uint16_
 		break;
 
 	case USBD_IDX_SERIAL_STR:
-		USBD_GetString((uint8_t *)self.usb_serialnumber_string, desc_str_buf, p_len);
+		USBD_GetString((uint8_t *)SELF.usb_serialnumber_string, desc_str_buf, p_len);
 		break;
 
 	case USBD_USER_STRING_CDC_IDX:
@@ -330,7 +333,7 @@ static uint8_t *usb_desc_usr_str(USBD_HandleTypeDef *p_dev, uint8_t idx, uint16_
 
 void USB_IRQHandler(void)
 {
-	HAL_PCD_IRQHandler(&self.pcd_handle);
+	HAL_PCD_IRQHandler(&SELF.pcd_handle);
 }
 
 err_t usb_init(void)
@@ -338,33 +341,33 @@ err_t usb_init(void)
 	HAL_StatusTypeDef status;
 	err_t r;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	sprintf(self.usb_serialnumber_string, "%08lx%08lx", HAL_GetUIDw0() + HAL_GetUIDw2(), HAL_GetUIDw1());
+	sprintf(SELF.usb_serialnumber_string, "%08lx%08lx", HAL_GetUIDw0() + HAL_GetUIDw2(), HAL_GetUIDw1());
 
-	r = pcd_init(&self.usbd_handle);
+	r = pcd_init(&SELF.usbd_handle);
 	ERR_CHECK(r);
 
-	status = USBD_Init(&self.usbd_handle, &self.pcd_handle, &desc_funcs);
+	status = USBD_Init(&SELF.usbd_handle, &SELF.pcd_handle, &desc_funcs);
 	HAL_ERR_CHECK(status, EUSB_USBD_INIT);
 
 	r = usb_hid_init(&((struct hid_init_data){
-		.p_usbd = &self.usbd_handle,
-		.p_pcd = &self.pcd_handle
+		.p_usbd = &SELF.usbd_handle,
+		.p_pcd = &SELF.pcd_handle
 	}));
 	ERR_CHECK(r);
 
 	r = usb_cdc_init(&((struct cdc_init_data){
-		.p_usbd = &self.usbd_handle,
-		.p_pcd = &self.pcd_handle
+		.p_usbd = &SELF.usbd_handle,
+		.p_pcd = &SELF.pcd_handle
 	}));
 	ERR_CHECK(r);
 
 	status = USBD_Start();
 	HAL_ERR_CHECK(status, EUSB_USBD_START);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32f0xx/usb.c
+++ b/platforms/stm32f0xx/usb.c
@@ -10,7 +10,7 @@
 #include "usb/ctlreq.h"
 #include "usb/hid_internal.h"
 
-#define MODULE_NAME				STM32F0XX_USB
+#define MODULE_NAME				stm32f0xx_usb
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32f0xx/usb/cdc.c
+++ b/platforms/stm32f0xx/usb/cdc.c
@@ -12,7 +12,7 @@
 #include "stm32f0xx_hal.h"
 #include "cdc_internal.h"
 
-#define MODULE_NAME		USB_CDC
+#define MODULE_NAME		usb_cdc
 #include "macros.h"
 
 #define CLASS_IDX		1

--- a/platforms/stm32f0xx/usb/cdc.c
+++ b/platforms/stm32f0xx/usb/cdc.c
@@ -12,6 +12,9 @@
 #include "stm32f0xx_hal.h"
 #include "cdc_internal.h"
 
+#define MODULE_NAME		USB_CDC
+#include "macros.h"
+
 #define CLASS_IDX		1
 #define QUEUE_LENGTH	10
 #define QUEUE_ITEM_SIZE	sizeof(struct usb_rx_queue_item)
@@ -30,7 +33,7 @@ static struct {
 	uint8_t rx_queue_storage[QUEUE_LENGTH * QUEUE_ITEM_SIZE];
 	SemaphoreHandle_t tx_done_semaphore;
 	StaticSemaphore_t tx_done_semaphore_buffer;
-} self;
+} SELF;
 
 static uint8_t cdc_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
 static uint8_t cdc_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
@@ -113,20 +116,20 @@ static void cdc_ctrl(uint8_t cmd, uint8_t *p_buf, uint16_t len)
 
 static uint8_t cdc_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Open(self.p_pcd, CDC_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
-	HAL_PCD_EP_Open(self.p_pcd, CDC_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
-	HAL_PCD_EP_Open(self.p_pcd, CDC_CMD_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
+	HAL_PCD_EP_Open(SELF.p_pcd, CDC_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
+	HAL_PCD_EP_Open(SELF.p_pcd, CDC_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
+	HAL_PCD_EP_Open(SELF.p_pcd, CDC_CMD_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
 
-	HAL_PCD_EP_Receive(self.p_pcd, CDC_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_PCD_EP_Receive(SELF.p_pcd, CDC_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
 
 	return HAL_OK;
 }
 
 static uint8_t cdc_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Close(self.p_pcd, CDC_IN_EP);
-	HAL_PCD_EP_Close(self.p_pcd, CDC_OUT_EP);
-	HAL_PCD_EP_Close(self.p_pcd, CDC_CMD_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, CDC_IN_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, CDC_OUT_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, CDC_CMD_EP);
 
 	return HAL_OK;
 }
@@ -139,13 +142,13 @@ static uint8_t cdc_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 				(p_req->wIndex == USB_CDC_CTRL_INTERFACE_NO)) {
 			if (p_req->wLength) {
 				if (p_req->bmRequest.dir) {
-					cdc_ctrl(p_req->bRequest, (uint8_t *)self.ctrl_buf, p_req->wLength);
-					USBD_CtlSendData(p_dev, (uint8_t *)self.ctrl_buf, p_req->wLength);
+					cdc_ctrl(p_req->bRequest, (uint8_t *)SELF.ctrl_buf, p_req->wLength);
+					USBD_CtlSendData(p_dev, (uint8_t *)SELF.ctrl_buf, p_req->wLength);
 				} else {
-					self.ctrl_op_code = p_req->bRequest;
-					self.ctrl_len = p_req->wLength;
+					SELF.ctrl_op_code = p_req->bRequest;
+					SELF.ctrl_len = p_req->wLength;
 
-					USBD_CtlPrepareRx(p_dev, (uint8_t *)self.ctrl_buf, p_req->wLength);
+					USBD_CtlPrepareRx(p_dev, (uint8_t *)SELF.ctrl_buf, p_req->wLength);
 				}
 			} else {
 				cdc_ctrl(p_req->bRequest, (uint8_t *)p_req, 0);
@@ -156,11 +159,11 @@ static uint8_t cdc_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 	case USB_REQ_TYPE_STANDARD:
 		switch (p_req->bRequest) {
 		case USB_REQ_GET_INTERFACE:
-			USBD_CtlSendData(p_dev, &self.alt_interface, 1);
+			USBD_CtlSendData(p_dev, &SELF.alt_interface, 1);
 			break;
 
 		case USB_REQ_SET_INTERFACE:
-			self.alt_interface = p_req->wValue;
+			SELF.alt_interface = p_req->wValue;
 			break;
 		}
 
@@ -178,7 +181,7 @@ static uint8_t cdc_data_in(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != CDC_IN_EP)
 		return HAL_OK;
 
-	xSemaphoreGiveFromISR(self.tx_done_semaphore, &xHigherPriorityTaskWoken);
+	xSemaphoreGiveFromISR(SELF.tx_done_semaphore, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return HAL_OK;
@@ -192,10 +195,10 @@ static uint8_t cdc_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != CDC_OUT_EP)
 		return HAL_OK;
 
-	self.rx_buf.len = HAL_PCD_EP_GetRxCount(self.p_pcd, epnum);
-	status = HAL_PCD_EP_Receive(self.p_pcd, CDC_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	SELF.rx_buf.len = HAL_PCD_EP_GetRxCount(SELF.p_pcd, epnum);
+	status = HAL_PCD_EP_Receive(SELF.p_pcd, CDC_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
  
-	xQueueSendFromISR(self.rx_queue_handle, &self.rx_buf, &xHigherPriorityTaskWoken);
+	xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_buf, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return status;
@@ -203,25 +206,25 @@ static uint8_t cdc_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 
 static uint8_t cdc_ep0_rx_ready(USBD_HandleTypeDef *p_dev)
 {
-	if (self.ctrl_op_code == 0xFF)
+	if (SELF.ctrl_op_code == 0xFF)
 		return HAL_OK;
 
-	cdc_ctrl(self.ctrl_op_code, (uint8_t *)self.ctrl_buf, self.ctrl_len);
+	cdc_ctrl(SELF.ctrl_op_code, (uint8_t *)SELF.ctrl_buf, SELF.ctrl_len);
 
-	self.ctrl_op_code = 0xFF;
+	SELF.ctrl_op_code = 0xFF;
 
 	return HAL_OK;
 }
 
 err_t usb_cdc_rx(struct usb_rx_queue_item *p_rx_queue_item, uint32_t timeout_ticks)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_CDC_NO_INIT;
 
 	if (!p_rx_queue_item)
 		return EUSB_CDC_INVALID_ARG;
 
-	if (xQueueReceive(self.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
+	if (xQueueReceive(SELF.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
 		return EUSB_CDC_RX_TIMEOUT;
 
 	return ERR_OK;
@@ -231,15 +234,15 @@ err_t usb_cdc_tx(uint8_t *p_buf, uint16_t len)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_CDC_NO_INIT;
 
-	if (self.p_usbd->dev_state != USBD_STATE_CONFIGURED)
+	if (SELF.p_usbd->dev_state != USBD_STATE_CONFIGURED)
 		return EUSB_CDC_NOT_READY;
 
-	xSemaphoreTake(self.tx_done_semaphore, portMAX_DELAY);
+	xSemaphoreTake(SELF.tx_done_semaphore, portMAX_DELAY);
 
-	status = HAL_PCD_EP_Transmit(self.p_pcd, CDC_IN_EP, p_buf, len);
+	status = HAL_PCD_EP_Transmit(SELF.p_pcd, CDC_IN_EP, p_buf, len);
 	HAL_ERR_CHECK(status, EUSB_CDC_TRANSMIT);
 
 	return ERR_OK;
@@ -249,29 +252,29 @@ err_t usb_cdc_init(const struct cdc_init_data *p_data)
 {
 	HAL_StatusTypeDef status;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.p_usbd = p_data->p_usbd;
-	self.p_pcd = p_data->p_pcd;
+	SELF.p_usbd = p_data->p_usbd;
+	SELF.p_pcd = p_data->p_pcd;
 
-	HAL_PCDEx_PMAConfig(self.p_pcd, CDC_CMD_EP, PCD_SNG_BUF, USB_PMA_BASE + 2 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, CDC_CMD_EP, PCD_SNG_BUF, USB_PMA_BASE + 2 * USB_FS_MAX_PACKET_SIZE);
 
-	HAL_PCDEx_PMAConfig(self.p_pcd, CDC_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 4 * USB_FS_MAX_PACKET_SIZE);
-	HAL_PCDEx_PMAConfig(self.p_pcd, CDC_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 5 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, CDC_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 4 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, CDC_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 5 * USB_FS_MAX_PACKET_SIZE);
 
-	status = USBD_RegisterClass(self.p_usbd, CLASS_IDX, &cdc_class_def);
+	status = USBD_RegisterClass(SELF.p_usbd, CLASS_IDX, &cdc_class_def);
 	HAL_ERR_CHECK(status, EUSB_CDC_REG_CLASS);
 
-	self.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
+	SELF.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
 		QUEUE_ITEM_SIZE,
-		self.rx_queue_storage,
-		&self.rx_queue);
+		SELF.rx_queue_storage,
+		&SELF.rx_queue);
 
-	self.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.tx_done_semaphore_buffer);
-	xSemaphoreGive(self.tx_done_semaphore);
+	SELF.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.tx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_done_semaphore);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32f0xx/usb/core.c
+++ b/platforms/stm32f0xx/usb/core.c
@@ -28,9 +28,12 @@
 #include "usb/core.h"
 #include "stm32f0xx_hal.h"
 
+#define MODULE_NAME				USB_CORE
+#include "macros.h"
+
 static struct {
 	PCD_HandleTypeDef *p_pcd;
-} self;
+} SELF;
 
 HAL_StatusTypeDef USBD_Init(USBD_HandleTypeDef *p_dev, PCD_HandleTypeDef *p_pcd, USBD_DescriptorsTypeDef *p_desc)
 {
@@ -40,16 +43,16 @@ HAL_StatusTypeDef USBD_Init(USBD_HandleTypeDef *p_dev, PCD_HandleTypeDef *p_pcd,
 	p_dev->pDesc = p_desc;
 	p_dev->dev_state = USBD_STATE_DEFAULT;
 
-	self.p_pcd = p_pcd;
-	self.p_pcd->Instance = USB;
-	self.p_pcd->Init.dev_endpoints = USBD_MAX_NUM_ENDPOINTS;
-	self.p_pcd->Init.speed = PCD_SPEED_FULL;
-	self.p_pcd->Init.ep0_mps = DEP0CTL_MPS_64;
-	self.p_pcd->Init.phy_itface = PCD_PHY_EMBEDDED;
-	self.p_pcd->Init.Sof_enable = DISABLE;
-	self.p_pcd->Init.low_power_enable = DISABLE;
-	self.p_pcd->Init.lpm_enable = DISABLE;
-	self.p_pcd->Init.battery_charging_enable = DISABLE;
+	SELF.p_pcd = p_pcd;
+	SELF.p_pcd->Instance = USB;
+	SELF.p_pcd->Init.dev_endpoints = USBD_MAX_NUM_ENDPOINTS;
+	SELF.p_pcd->Init.speed = PCD_SPEED_FULL;
+	SELF.p_pcd->Init.ep0_mps = DEP0CTL_MPS_64;
+	SELF.p_pcd->Init.phy_itface = PCD_PHY_EMBEDDED;
+	SELF.p_pcd->Init.Sof_enable = DISABLE;
+	SELF.p_pcd->Init.low_power_enable = DISABLE;
+	SELF.p_pcd->Init.lpm_enable = DISABLE;
+	SELF.p_pcd->Init.battery_charging_enable = DISABLE;
 
 	if (HAL_PCD_Init(p_pcd) != HAL_OK)
 		return HAL_ERROR;
@@ -67,7 +70,7 @@ HAL_StatusTypeDef USBD_DeInit(USBD_HandleTypeDef *p_dev)
 
 	USBD_Stop(p_dev);
 
-	return HAL_PCD_DeInit(self.p_pcd);
+	return HAL_PCD_DeInit(SELF.p_pcd);
 }
 
 HAL_StatusTypeDef USBD_RegisterClass(USBD_HandleTypeDef *p_dev, uint8_t idx, USBD_ClassTypeDef *p_class)
@@ -83,7 +86,7 @@ HAL_StatusTypeDef USBD_RegisterClass(USBD_HandleTypeDef *p_dev, uint8_t idx, USB
 
 HAL_StatusTypeDef USBD_Start(void)
 {
-	return HAL_PCD_Start(self.p_pcd);
+	return HAL_PCD_Start(SELF.p_pcd);
 }
 
 HAL_StatusTypeDef USBD_Stop(USBD_HandleTypeDef *p_dev)
@@ -92,7 +95,7 @@ HAL_StatusTypeDef USBD_Stop(USBD_HandleTypeDef *p_dev)
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i)
 		p_dev->pClasses[i]->DeInit(p_dev, p_dev->dev_config);
 
-	return HAL_PCD_Stop(self.p_pcd);
+	return HAL_PCD_Stop(SELF.p_pcd);
 }
 
 HAL_StatusTypeDef USBD_SetClassConfig(USBD_HandleTypeDef *p_dev, uint8_t idx, uint8_t cfgidx)
@@ -121,7 +124,7 @@ HAL_StatusTypeDef USBD_CtlSendData(USBD_HandleTypeDef *p_dev, uint8_t *p_buf, ui
 	p_dev->ep_in[0].rem_length   = len;
 
 	/* Start the transfer */
-	return HAL_PCD_EP_Transmit(self.p_pcd, 0x00, p_buf, len);
+	return HAL_PCD_EP_Transmit(SELF.p_pcd, 0x00, p_buf, len);
 }
 
 HAL_StatusTypeDef USBD_CtlPrepareRx(USBD_HandleTypeDef *p_dev, uint8_t *p_buf, uint16_t len)
@@ -132,7 +135,7 @@ HAL_StatusTypeDef USBD_CtlPrepareRx(USBD_HandleTypeDef *p_dev, uint8_t *p_buf, u
 	p_dev->ep_out[0].rem_length   = len;
 
 	/* Start the transfer */
-	return HAL_PCD_EP_Receive(self.p_pcd, 0x00, p_buf, len);
+	return HAL_PCD_EP_Receive(SELF.p_pcd, 0x00, p_buf, len);
 }
 
 HAL_StatusTypeDef USBD_CtlSendStatus(USBD_HandleTypeDef *p_dev)
@@ -141,13 +144,13 @@ HAL_StatusTypeDef USBD_CtlSendStatus(USBD_HandleTypeDef *p_dev)
 	p_dev->ep0_state = USBD_EP0_STATUS_IN;
 
 	/* Start the transfer */
-	return HAL_PCD_EP_Transmit(self.p_pcd, 0x00, NULL, 0);
+	return HAL_PCD_EP_Transmit(SELF.p_pcd, 0x00, NULL, 0);
 }
 
 uint8_t USBD_LL_IsStallEP(USBD_HandleTypeDef *p_dev, uint8_t ep_addr)
 {
 	if((ep_addr & 0x80) == 0x80)
-		return self.p_pcd->IN_ep[ep_addr & 0x7F].is_stall;
+		return SELF.p_pcd->IN_ep[ep_addr & 0x7F].is_stall;
 
-	return self.p_pcd->OUT_ep[ep_addr & 0x7F].is_stall;
+	return SELF.p_pcd->OUT_ep[ep_addr & 0x7F].is_stall;
 }

--- a/platforms/stm32f0xx/usb/core.c
+++ b/platforms/stm32f0xx/usb/core.c
@@ -28,7 +28,7 @@
 #include "usb/core.h"
 #include "stm32f0xx_hal.h"
 
-#define MODULE_NAME				USB_CORE
+#define MODULE_NAME				usb_core
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32f0xx/usb/hid.c
+++ b/platforms/stm32f0xx/usb/hid.c
@@ -11,6 +11,9 @@
 #include "stm32f0xx_hal.h"
 #include "hid_internal.h"
 
+#define MODULE_NAME		USB_HID
+#include "macros.h"
+
 #define CLASS_IDX		0
 #define QUEUE_LENGTH	10
 #define QUEUE_ITEM_SIZE	sizeof(struct usb_rx_queue_item)
@@ -29,7 +32,7 @@ static struct {
 	uint8_t rx_queue_storage[QUEUE_LENGTH * QUEUE_ITEM_SIZE];
 	SemaphoreHandle_t tx_done_semaphore;
 	StaticSemaphore_t tx_done_semaphore_buffer;
-} self;
+} SELF;
 
 static uint8_t hid_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
 static uint8_t hid_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
@@ -88,18 +91,18 @@ static uint8_t desc_hid[] = {
 
 static uint8_t hid_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Open(self.p_pcd, HID_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
-	HAL_PCD_EP_Open(self.p_pcd, HID_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
+	HAL_PCD_EP_Open(SELF.p_pcd, HID_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
+	HAL_PCD_EP_Open(SELF.p_pcd, HID_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
 
-	HAL_PCD_EP_Receive(self.p_pcd, HID_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_PCD_EP_Receive(SELF.p_pcd, HID_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
 
 	return HAL_OK;
 }
 
 static uint8_t hid_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Close(self.p_pcd, HID_IN_EP);
-	HAL_PCD_EP_Close(self.p_pcd, HID_OUT_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, HID_IN_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, HID_OUT_EP);
 
 	return HAL_OK;
 }
@@ -115,28 +118,28 @@ static uint8_t hid_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 				(p_req->wIndex == USB_HID_INTERFACE_NO)) {
 			switch (p_req->bRequest) {
 			case HID_REQ_SET_PROTOCOL:
-				self.protocol = (uint8_t)(p_req->wValue);
+				SELF.protocol = (uint8_t)(p_req->wValue);
 				break;
 
 			case HID_REQ_GET_PROTOCOL:
-				USBD_CtlSendData(p_dev, (uint8_t *)&self.protocol, 1);
+				USBD_CtlSendData(p_dev, (uint8_t *)&SELF.protocol, 1);
 				break;
 
 			case HID_REQ_SET_IDLE:
-				self.idle_state = (uint8_t)(p_req->wValue >> 8);
+				SELF.idle_state = (uint8_t)(p_req->wValue >> 8);
 				break;
 
 			case HID_REQ_GET_IDLE:
-				USBD_CtlSendData(p_dev, (uint8_t *)&self.idle_state, 1);
+				USBD_CtlSendData(p_dev, (uint8_t *)&SELF.idle_state, 1);
 				break;
 
 			case HID_REQ_SET_REPORT:
-				self.report_available = true;
-				USBD_CtlPrepareRx(p_dev, self.rx_buf.data, p_req->wLength);
+				SELF.report_available = true;
+				USBD_CtlPrepareRx(p_dev, SELF.rx_buf.data, p_req->wLength);
 				break;
 
 			default:
-				USBD_CtlError(self.p_pcd);
+				USBD_CtlError(SELF.p_pcd);
 				return HAL_ERROR;
 			}
 		}
@@ -157,11 +160,11 @@ static uint8_t hid_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 			break;
 
 		case USB_REQ_GET_INTERFACE:
-			USBD_CtlSendData(p_dev, (uint8_t *)&self.alt_interface, 1);
+			USBD_CtlSendData(p_dev, (uint8_t *)&SELF.alt_interface, 1);
 			break;
 
 		case USB_REQ_SET_INTERFACE:
-			self.alt_interface = (uint8_t)(p_req->wValue);
+			SELF.alt_interface = (uint8_t)(p_req->wValue);
 			break;
 		}
 	}
@@ -171,10 +174,10 @@ static uint8_t hid_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 
 static uint8_t hid_ep0_rx_ready(USBD_HandleTypeDef *p_dev)
 {
-	if (!self.report_available)
+	if (!SELF.report_available)
 		return HAL_OK;
 
-	self.report_available = false;
+	SELF.report_available = false;
 
 	return HAL_OK;
 }
@@ -186,7 +189,7 @@ static uint8_t hid_data_in(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != HID_IN_EP)
 		return HAL_OK;
 
-	xSemaphoreGiveFromISR(self.tx_done_semaphore, &xHigherPriorityTaskWoken);
+	xSemaphoreGiveFromISR(SELF.tx_done_semaphore, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return HAL_OK;
@@ -200,10 +203,10 @@ static uint8_t hid_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != HID_OUT_EP)
 		return HAL_OK;
 
-	self.rx_buf.len = HAL_PCD_EP_GetRxCount(self.p_pcd, epnum);
-	status = HAL_PCD_EP_Receive(self.p_pcd, HID_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	SELF.rx_buf.len = HAL_PCD_EP_GetRxCount(SELF.p_pcd, epnum);
+	status = HAL_PCD_EP_Receive(SELF.p_pcd, HID_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
 
-	xQueueSendFromISR(self.rx_queue_handle, &self.rx_buf, &xHigherPriorityTaskWoken);
+	xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_buf, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return status;
@@ -211,13 +214,13 @@ static uint8_t hid_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 
 err_t usb_hid_recv(struct usb_rx_queue_item *p_rx_queue_item, uint32_t timeout_ticks)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_HID_NO_INIT;
 
 	if (!p_rx_queue_item)
 		return EUSB_HID_INVALID_ARG;
 
-	if (xQueueReceive(self.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
+	if (xQueueReceive(SELF.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
 		return EUSB_HID_RECV_TIMEOUT;
 
 	return ERR_OK;
@@ -227,15 +230,15 @@ err_t usb_hid_send(uint8_t *p_buf, uint16_t len)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_HID_NO_INIT;
 
-	if (self.p_usbd->dev_state != USBD_STATE_CONFIGURED)
+	if (SELF.p_usbd->dev_state != USBD_STATE_CONFIGURED)
 		return EUSB_HID_NOT_READY;
 
-	xSemaphoreTake(self.tx_done_semaphore, portMAX_DELAY);
+	xSemaphoreTake(SELF.tx_done_semaphore, portMAX_DELAY);
 
-	status = HAL_PCD_EP_Transmit(self.p_pcd, HID_IN_EP, p_buf, len);
+	status = HAL_PCD_EP_Transmit(SELF.p_pcd, HID_IN_EP, p_buf, len);
 	HAL_ERR_CHECK(status, EUSB_HID_TRANSMIT);
 
 	return ERR_OK;
@@ -245,27 +248,27 @@ err_t usb_hid_init(const struct hid_init_data *p_data)
 {
 	HAL_StatusTypeDef status;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.p_usbd = p_data->p_usbd;
-	self.p_pcd = p_data->p_pcd;
+	SELF.p_usbd = p_data->p_usbd;
+	SELF.p_pcd = p_data->p_pcd;
 
-	HAL_PCDEx_PMAConfig(self.p_pcd, HID_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 3 * USB_FS_MAX_PACKET_SIZE);
-	HAL_PCDEx_PMAConfig(self.p_pcd, HID_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 6 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, HID_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 3 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, HID_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 6 * USB_FS_MAX_PACKET_SIZE);
 
-	status = USBD_RegisterClass(self.p_usbd, CLASS_IDX, &hid_class_def);
+	status = USBD_RegisterClass(SELF.p_usbd, CLASS_IDX, &hid_class_def);
 	HAL_ERR_CHECK(status, EUSB_HID_REG_CLASS);
 
-	self.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
+	SELF.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
 		QUEUE_ITEM_SIZE,
-		self.rx_queue_storage,
-		&self.rx_queue);
+		SELF.rx_queue_storage,
+		&SELF.rx_queue);
 
-	self.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.tx_done_semaphore_buffer);
-	xSemaphoreGive(self.tx_done_semaphore);
+	SELF.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.tx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_done_semaphore);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32f0xx/usb/hid.c
+++ b/platforms/stm32f0xx/usb/hid.c
@@ -11,7 +11,7 @@
 #include "stm32f0xx_hal.h"
 #include "hid_internal.h"
 
-#define MODULE_NAME		USB_HID
+#define MODULE_NAME		usb_hid
 #include "macros.h"
 
 #define CLASS_IDX		0

--- a/platforms/stm32l4xx/i2c.c
+++ b/platforms/stm32l4xx/i2c.c
@@ -1,13 +1,16 @@
 #include <stdbool.h>
 
+#include "hal_errors.h"
 #include "platform/gpio.h"
 #include "platform/i2c.h"
-#include "hal_errors.h"
+
+#define MODULE_NAME				I2C
+#include "macros.h"
 
 static struct {
 	bool initialized;
 	I2C_HandleTypeDef i2c_handle;
-} self;
+} SELF;
 
 void HAL_I2C_MspInit(I2C_HandleTypeDef *p_handle)
 {
@@ -38,10 +41,10 @@ err_t i2c_master_tx(uint16_t dev_address, uint8_t *p_data, uint16_t size, uint32
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EI2C_NO_INIT;
 
-	status = HAL_I2C_Master_Transmit(&self.i2c_handle, dev_address, p_data, size, timeout_ms);
+	status = HAL_I2C_Master_Transmit(&SELF.i2c_handle, dev_address, p_data, size, timeout_ms);
 	HAL_ERR_CHECK(status, EI2C_HAL_MASTER_TRANSMIT);
 
 	return ERR_OK;
@@ -51,10 +54,10 @@ err_t i2c_master_rx(uint16_t dev_address, uint8_t *p_data, uint16_t size, uint32
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EI2C_NO_INIT;
 
-	status = HAL_I2C_Master_Receive(&self.i2c_handle, dev_address, p_data, size, timeout_ms);
+	status = HAL_I2C_Master_Receive(&SELF.i2c_handle, dev_address, p_data, size, timeout_ms);
 	HAL_ERR_CHECK(status, EI2C_HAL_MASTER_RECEIVE);
 
 	return ERR_OK;
@@ -64,29 +67,29 @@ err_t i2c_init(void)
 {
 	HAL_StatusTypeDef status;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.i2c_handle.Instance = I2C1;
-	self.i2c_handle.Init.Timing = 0x10909EEE;
-	self.i2c_handle.Init.OwnAddress1 = 0;
-	self.i2c_handle.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-	self.i2c_handle.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-	self.i2c_handle.Init.OwnAddress2 = 0;
-	self.i2c_handle.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-	self.i2c_handle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-	self.i2c_handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+	SELF.i2c_handle.Instance = I2C1;
+	SELF.i2c_handle.Init.Timing = 0x10909EEE;
+	SELF.i2c_handle.Init.OwnAddress1 = 0;
+	SELF.i2c_handle.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+	SELF.i2c_handle.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+	SELF.i2c_handle.Init.OwnAddress2 = 0;
+	SELF.i2c_handle.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+	SELF.i2c_handle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+	SELF.i2c_handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
 
-	status = HAL_I2C_Init(&self.i2c_handle);
+	status = HAL_I2C_Init(&SELF.i2c_handle);
 	HAL_ERR_CHECK(status, EI2C_HAL_INIT);
 
-	status = HAL_I2CEx_ConfigAnalogFilter(&self.i2c_handle, I2C_ANALOGFILTER_ENABLE);
+	status = HAL_I2CEx_ConfigAnalogFilter(&SELF.i2c_handle, I2C_ANALOGFILTER_ENABLE);
 	HAL_ERR_CHECK(status, EI2C_HAL_CONFIG_ANALOG_FILTER);
 
-	status = HAL_I2CEx_ConfigDigitalFilter(&self.i2c_handle, 0);
+	status = HAL_I2CEx_ConfigDigitalFilter(&SELF.i2c_handle, 0);
 	HAL_ERR_CHECK(status, EI2C_HAL_CONFIG_DIGITAL_FILTER);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32l4xx/i2c.c
+++ b/platforms/stm32l4xx/i2c.c
@@ -4,7 +4,7 @@
 #include "platform/gpio.h"
 #include "platform/i2c.h"
 
-#define MODULE_NAME				I2C
+#define MODULE_NAME				i2c
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32l4xx/pcd.c
+++ b/platforms/stm32l4xx/pcd.c
@@ -6,7 +6,7 @@
 #include "usb/core.h"
 #include "usb/ctlreq.h"
 
-#define MODULE_NAME				PCD
+#define MODULE_NAME				pcd
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32l4xx/pcd.c
+++ b/platforms/stm32l4xx/pcd.c
@@ -2,13 +2,16 @@
 #include <string.h>
 
 #include "pcd.h"
-#include "usb/ctlreq.h"
-#include "usb/core.h"
 #include "stm32l4xx_hal.h"
+#include "usb/core.h"
+#include "usb/ctlreq.h"
+
+#define MODULE_NAME				PCD
+#include "macros.h"
 
 static struct {
 	USBD_HandleTypeDef *p_usbd;
-} self;
+} SELF;
 
 extern HAL_StatusTypeDef SystemClock_Config(void);
 
@@ -37,30 +40,30 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *p_pcd)
 {
 	uint8_t *p_setup = (uint8_t *)p_pcd->Setup;
 
-	memcpy(&self.p_usbd->request.bmRequest, p_setup, 1);
-	self.p_usbd->request.bRequest  = *(uint8_t *)(p_setup +  1);
-	self.p_usbd->request.wValue    =     SWAPBYTE(p_setup +  2);
-	self.p_usbd->request.wIndex    =     SWAPBYTE(p_setup +  4);
-	self.p_usbd->request.wLength   =     SWAPBYTE(p_setup +  6);
+	memcpy(&SELF.p_usbd->request.bmRequest, p_setup, 1);
+	SELF.p_usbd->request.bRequest  = *(uint8_t *)(p_setup +  1);
+	SELF.p_usbd->request.wValue    =     SWAPBYTE(p_setup +  2);
+	SELF.p_usbd->request.wIndex    =     SWAPBYTE(p_setup +  4);
+	SELF.p_usbd->request.wLength   =     SWAPBYTE(p_setup +  6);
 
-	self.p_usbd->ep0_state = USBD_EP0_SETUP;
-	self.p_usbd->ep0_data_len = self.p_usbd->request.wLength;
+	SELF.p_usbd->ep0_state = USBD_EP0_SETUP;
+	SELF.p_usbd->ep0_data_len = SELF.p_usbd->request.wLength;
 
-	switch (self.p_usbd->request.bmRequest.recipient) {
+	switch (SELF.p_usbd->request.bmRequest.recipient) {
 	case USB_REQ_RECIPIENT_DEVICE:
-		USBD_StdDevReq(self.p_usbd, p_pcd, &self.p_usbd->request);
+		USBD_StdDevReq(SELF.p_usbd, p_pcd, &SELF.p_usbd->request);
 		break;
 
 	case USB_REQ_RECIPIENT_INTERFACE:
-		USBD_StdItfReq(self.p_usbd, p_pcd, &self.p_usbd->request);
+		USBD_StdItfReq(SELF.p_usbd, p_pcd, &SELF.p_usbd->request);
 		break;
 
 	case USB_REQ_RECIPIENT_ENDPOINT:
-		USBD_StdEPReq(self.p_usbd, p_pcd, &self.p_usbd->request);
+		USBD_StdEPReq(SELF.p_usbd, p_pcd, &SELF.p_usbd->request);
 		break;
 
 	default:
-		HAL_PCD_EP_SetStall(p_pcd, *(uint8_t*)(&self.p_usbd->request.bmRequest) & 0x80);
+		HAL_PCD_EP_SetStall(p_pcd, *(uint8_t*)(&SELF.p_usbd->request.bmRequest) & 0x80);
 		break;
 	}
 }
@@ -68,27 +71,27 @@ void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *p_pcd)
 void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *p_pcd, uint8_t epnum)
 {
 	if (epnum == 0x00) {
-		USBD_EndpointTypeDef *p_ep = &self.p_usbd->ep_out[0];
+		USBD_EndpointTypeDef *p_ep = &SELF.p_usbd->ep_out[0];
 		uint8_t *p_data = p_pcd->OUT_ep[epnum].xfer_buff;
 
-		if (self.p_usbd->ep0_state == USBD_EP0_DATA_OUT) {
+		if (SELF.p_usbd->ep0_state == USBD_EP0_DATA_OUT) {
 			if (p_ep->rem_length > p_ep->maxpacket) {
 				p_ep->rem_length -= p_ep->maxpacket;
 
 				HAL_PCD_EP_Receive(p_pcd, 0x00, p_data, MIN(p_ep->rem_length, p_ep->maxpacket));
 			} else {
 				for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-					if ((self.p_usbd->pClasses[i]->EP0_RxReady != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-						self.p_usbd->pClasses[i]->EP0_RxReady(self.p_usbd);
+					if ((SELF.p_usbd->pClasses[i]->EP0_RxReady != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+						SELF.p_usbd->pClasses[i]->EP0_RxReady(SELF.p_usbd);
 				}
 
-				USBD_CtlSendStatus(self.p_usbd);
+				USBD_CtlSendStatus(SELF.p_usbd);
 			}
 		}
 	} else {
 		for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-			if ((self.p_usbd->pClasses[i]->DataOut != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-				self.p_usbd->pClasses[i]->DataOut(self.p_usbd, epnum);
+			if ((SELF.p_usbd->pClasses[i]->DataOut != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+				SELF.p_usbd->pClasses[i]->DataOut(SELF.p_usbd, epnum);
 		}
 	}
 }
@@ -99,9 +102,9 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *p_pcd, uint8_t epnum)
 	USBD_EndpointTypeDef *p_ep;
 
 	if (epnum == 0x00) {
-		p_ep = &self.p_usbd->ep_in[0];
+		p_ep = &SELF.p_usbd->ep_in[0];
 
-		if ( self.p_usbd->ep0_state == USBD_EP0_DATA_IN) {
+		if ( SELF.p_usbd->ep0_state == USBD_EP0_DATA_IN) {
 			if (p_ep->rem_length > p_ep->maxpacket) {
 				p_ep->rem_length -=  p_ep->maxpacket;
 
@@ -110,68 +113,68 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *p_pcd, uint8_t epnum)
 				/* Prepare endpoint for premature end of transfer */
 				HAL_PCD_EP_Receive(p_pcd, 0, NULL, 0);
 			} else { /* last packet is MPS multiple, so send ZLP packet */
-				if ((p_ep->total_length % p_ep->maxpacket == 0) && (p_ep->total_length >= p_ep->maxpacket) && (p_ep->total_length < self.p_usbd->ep0_data_len )) {
+				if ((p_ep->total_length % p_ep->maxpacket == 0) && (p_ep->total_length >= p_ep->maxpacket) && (p_ep->total_length < SELF.p_usbd->ep0_data_len )) {
 					HAL_PCD_EP_Transmit(p_pcd, 0x00, NULL, 0);
-					self.p_usbd->ep0_data_len = 0;
+					SELF.p_usbd->ep0_data_len = 0;
 
 					/* Prepare endpoint for premature end of transfer */
 					HAL_PCD_EP_Receive(p_pcd, 0, NULL, 0);
 				} else {
 					for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-						if ((self.p_usbd->pClasses[i]->EP0_TxSent != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-							self.p_usbd->pClasses[i]->EP0_TxSent(self.p_usbd);
+						if ((SELF.p_usbd->pClasses[i]->EP0_TxSent != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+							SELF.p_usbd->pClasses[i]->EP0_TxSent(SELF.p_usbd);
 					}
 
-					self.p_usbd->ep0_state = USBD_EP0_STATUS_OUT;
+					SELF.p_usbd->ep0_state = USBD_EP0_STATUS_OUT;
 					HAL_PCD_EP_Receive(p_pcd, 0x00, NULL, 0);
 				}
 			}
 		}
 	} else {
 		for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-			if ((self.p_usbd->pClasses[i]->DataIn != NULL) && (self.p_usbd->dev_state == USBD_STATE_CONFIGURED))
-				self.p_usbd->pClasses[i]->DataIn(self.p_usbd, epnum | 0x80);
+			if ((SELF.p_usbd->pClasses[i]->DataIn != NULL) && (SELF.p_usbd->dev_state == USBD_STATE_CONFIGURED))
+				SELF.p_usbd->pClasses[i]->DataIn(SELF.p_usbd, epnum | 0x80);
 		}
 	}
 }
 
 void HAL_PCD_SOFCallback(PCD_HandleTypeDef *p_pcd)
 {
-	if (self.p_usbd->dev_state != USBD_STATE_CONFIGURED)
+	if (SELF.p_usbd->dev_state != USBD_STATE_CONFIGURED)
 		return;
 
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i) {
-		if (self.p_usbd->pClasses[i]->SOF != NULL)
-			self.p_usbd->pClasses[i]->SOF(self.p_usbd);
+		if (SELF.p_usbd->pClasses[i]->SOF != NULL)
+			SELF.p_usbd->pClasses[i]->SOF(SELF.p_usbd);
 	}
 }
 
 void HAL_PCD_ResetCallback(PCD_HandleTypeDef *p_pcd)
 {
-	self.p_usbd->dev_speed = USBD_SPEED_FULL;
+	SELF.p_usbd->dev_speed = USBD_SPEED_FULL;
 
 	/* Open EP0 OUT */
 	HAL_PCD_EP_Open(p_pcd, 0x00, USB_MAX_EP0_SIZE, USBD_EP_TYPE_CTRL);
 
-	self.p_usbd->ep_out[0].maxpacket = USB_MAX_EP0_SIZE;
+	SELF.p_usbd->ep_out[0].maxpacket = USB_MAX_EP0_SIZE;
 
 	/* Open EP0 IN */
 	HAL_PCD_EP_Open(p_pcd, 0x80, USB_MAX_EP0_SIZE, USBD_EP_TYPE_CTRL);
 
-	self.p_usbd->ep_in[0].maxpacket = USB_MAX_EP0_SIZE;
+	SELF.p_usbd->ep_in[0].maxpacket = USB_MAX_EP0_SIZE;
 
 	/* Upon Reset call user call back */
-	self.p_usbd->dev_state = USBD_STATE_DEFAULT;
+	SELF.p_usbd->dev_state = USBD_STATE_DEFAULT;
 
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i)
-		self.p_usbd->pClasses[i]->DeInit(self.p_usbd, self.p_usbd->dev_config);
+		SELF.p_usbd->pClasses[i]->DeInit(SELF.p_usbd, SELF.p_usbd->dev_config);
 }
 
 void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *p_pcd)
 {
 	/* Inform USB library that core enters in suspend Mode. */
-	self.p_usbd->dev_old_state = self.p_usbd->dev_state;
-	self.p_usbd->dev_state = USBD_STATE_SUSPENDED;
+	SELF.p_usbd->dev_old_state = SELF.p_usbd->dev_state;
+	SELF.p_usbd->dev_state = USBD_STATE_SUSPENDED;
 
 	/* Enter in STOP mode. */
 	if (p_pcd->Init.low_power_enable) {
@@ -188,16 +191,16 @@ void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *p_pcd)
 		SystemClock_Config();
 	}
 
-	self.p_usbd->dev_state = self.p_usbd->dev_old_state;
+	SELF.p_usbd->dev_state = SELF.p_usbd->dev_old_state;
 }
 
 void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *p_pcd)
 {
 	/* Free Class Resources */
-	self.p_usbd->dev_state = USBD_STATE_DEFAULT;
+	SELF.p_usbd->dev_state = USBD_STATE_DEFAULT;
 
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i)
-		self.p_usbd->pClasses[i]->DeInit(self.p_usbd, self.p_usbd->dev_config);
+		SELF.p_usbd->pClasses[i]->DeInit(SELF.p_usbd, SELF.p_usbd->dev_config);
 }
 
 void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *p_pcd, PCD_LPM_MsgTypeDef msg)
@@ -211,12 +214,12 @@ void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *p_pcd, PCD_LPM_MsgTypeDef msg)
 			SCB->SCR &= (uint32_t)~((uint32_t)(SCB_SCR_SLEEPDEEP_Msk | SCB_SCR_SLEEPONEXIT_Msk));
 		}
 
-		self.p_usbd->dev_state = self.p_usbd->dev_old_state;
+		SELF.p_usbd->dev_state = SELF.p_usbd->dev_old_state;
 		break;
 
 	case PCD_LPM_L1_ACTIVE:
-		self.p_usbd->dev_old_state = self.p_usbd->dev_state;
-		self.p_usbd->dev_state = USBD_STATE_SUSPENDED;
+		SELF.p_usbd->dev_old_state = SELF.p_usbd->dev_state;
+		SELF.p_usbd->dev_state = USBD_STATE_SUSPENDED;
 
 		/* Enter in STOP mode. */
 		if (p_pcd->Init.low_power_enable) {
@@ -229,7 +232,7 @@ void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *p_pcd, PCD_LPM_MsgTypeDef msg)
 
 err_t pcd_init(USBD_HandleTypeDef *p_usbd)
 {
-	self.p_usbd = p_usbd;
+	SELF.p_usbd = p_usbd;
 
 	return ERR_OK;
 }

--- a/platforms/stm32l4xx/uart.c
+++ b/platforms/stm32l4xx/uart.c
@@ -11,7 +11,7 @@
 #include "stm32l4xx_hal.h"
 #include "stm32l4xx_ll_dma.h"
 
-#define MODULE_NAME				UART
+#define MODULE_NAME				uart
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32l4xx/uart.c
+++ b/platforms/stm32l4xx/uart.c
@@ -11,6 +11,9 @@
 #include "stm32l4xx_hal.h"
 #include "stm32l4xx_ll_dma.h"
 
+#define MODULE_NAME				UART
+#include "macros.h"
+
 static struct {
 	DMA_HandleTypeDef hdma_usart3_tx;
 	DMA_HandleTypeDef hdma_usart3_rx;
@@ -31,7 +34,7 @@ static struct {
 
 	bool enabled;
 	bool initialized;
-} self;
+} SELF;
 
 void HAL_UART_MspInit(UART_HandleTypeDef *p_handle)
 {
@@ -49,36 +52,36 @@ void HAL_UART_MspInit(UART_HandleTypeDef *p_handle)
 		gpio_config.Alternate = GPIO_AF7_USART3;
 		HAL_GPIO_Init(GPIOB, &gpio_config);
 		
-		self.hdma_usart3_tx.Instance = DMA1_Channel2;
-		self.hdma_usart3_tx.Init.Request = DMA_REQUEST_2;
-		self.hdma_usart3_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-		self.hdma_usart3_tx.Init.PeriphInc = DMA_PINC_DISABLE;
-		self.hdma_usart3_tx.Init.MemInc = DMA_MINC_ENABLE;
-		self.hdma_usart3_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-		self.hdma_usart3_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-		self.hdma_usart3_tx.Init.Mode = DMA_NORMAL;
-		self.hdma_usart3_tx.Init.Priority = DMA_PRIORITY_LOW;
-		status = HAL_DMA_Init(&self.hdma_usart3_tx);
+		SELF.hdma_usart3_tx.Instance = DMA1_Channel2;
+		SELF.hdma_usart3_tx.Init.Request = DMA_REQUEST_2;
+		SELF.hdma_usart3_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+		SELF.hdma_usart3_tx.Init.PeriphInc = DMA_PINC_DISABLE;
+		SELF.hdma_usart3_tx.Init.MemInc = DMA_MINC_ENABLE;
+		SELF.hdma_usart3_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+		SELF.hdma_usart3_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+		SELF.hdma_usart3_tx.Init.Mode = DMA_NORMAL;
+		SELF.hdma_usart3_tx.Init.Priority = DMA_PRIORITY_LOW;
+		status = HAL_DMA_Init(&SELF.hdma_usart3_tx);
 		if (status != HAL_OK)
 			for (;;);
 
-		__HAL_LINKDMA(p_handle, hdmatx, self.hdma_usart3_tx);
+		__HAL_LINKDMA(p_handle, hdmatx, SELF.hdma_usart3_tx);
 
 		/* USART3_RX Init */
-		self.hdma_usart3_rx.Instance = DMA1_Channel3;
-		self.hdma_usart3_rx.Init.Request = DMA_REQUEST_2;
-		self.hdma_usart3_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-		self.hdma_usart3_rx.Init.PeriphInc = DMA_PINC_DISABLE;
-		self.hdma_usart3_rx.Init.MemInc = DMA_MINC_ENABLE;
-		self.hdma_usart3_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-		self.hdma_usart3_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-		self.hdma_usart3_rx.Init.Mode = DMA_NORMAL;
-		self.hdma_usart3_rx.Init.Priority = DMA_PRIORITY_LOW;
-		status = HAL_DMA_Init(&self.hdma_usart3_rx);
+		SELF.hdma_usart3_rx.Instance = DMA1_Channel3;
+		SELF.hdma_usart3_rx.Init.Request = DMA_REQUEST_2;
+		SELF.hdma_usart3_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
+		SELF.hdma_usart3_rx.Init.PeriphInc = DMA_PINC_DISABLE;
+		SELF.hdma_usart3_rx.Init.MemInc = DMA_MINC_ENABLE;
+		SELF.hdma_usart3_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+		SELF.hdma_usart3_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+		SELF.hdma_usart3_rx.Init.Mode = DMA_NORMAL;
+		SELF.hdma_usart3_rx.Init.Priority = DMA_PRIORITY_LOW;
+		status = HAL_DMA_Init(&SELF.hdma_usart3_rx);
 		if (status != HAL_OK)
 			for (;;);
 
-		__HAL_LINKDMA(p_handle, hdmarx, self.hdma_usart3_rx);
+		__HAL_LINKDMA(p_handle, hdmarx, SELF.hdma_usart3_rx);
 
 		/* USART3 interrupt Init */
 		HAL_NVIC_SetPriority(USART3_IRQn, 5, 0);
@@ -111,7 +114,7 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *p_uart)
 {
 	static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	xSemaphoreGiveFromISR(self.tx_done_semaphore, &xHigherPriorityTaskWoken);
+	xSemaphoreGiveFromISR(SELF.tx_done_semaphore, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
@@ -119,39 +122,39 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *p_uart)
 {
 	static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	self.rx_item.len = USB_FS_MAX_PACKET_SIZE;
-	xQueueSendFromISR(self.rx_queue_handle, &self.rx_item, &xHigherPriorityTaskWoken);
+	SELF.rx_item.len = USB_FS_MAX_PACKET_SIZE;
+	xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_item, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-	HAL_UART_Receive_DMA(&self.uart_handle, (uint8_t*) self.rx_item.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_UART_Receive_DMA(&SELF.uart_handle, (uint8_t*) SELF.rx_item.data, USB_FS_MAX_PACKET_SIZE);
 }
 
 void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *p_uart)
 {
 	static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	self.rx_item.len = USB_FS_MAX_PACKET_SIZE - LL_DMA_GetDataLength(DMA1, LL_DMA_CHANNEL_3);
+	SELF.rx_item.len = USB_FS_MAX_PACKET_SIZE - LL_DMA_GetDataLength(DMA1, LL_DMA_CHANNEL_3);
 
-	if (self.rx_item.len) {
-		xQueueSendFromISR(self.rx_queue_handle, &self.rx_item, &xHigherPriorityTaskWoken);
+	if (SELF.rx_item.len) {
+		xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_item, &xHigherPriorityTaskWoken);
 		portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 	}
 
-	HAL_UART_Receive_DMA(&self.uart_handle, (uint8_t*) self.rx_item.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_UART_Receive_DMA(&SELF.uart_handle, (uint8_t*) SELF.rx_item.data, USB_FS_MAX_PACKET_SIZE);
 }
 
 void USART3_IRQHandler(void)
 {
-	HAL_UART_IRQHandler(&self.uart_handle);
+	HAL_UART_IRQHandler(&SELF.uart_handle);
 }
 
 void DMA1_Channel2_IRQHandler(void)
 {
-	HAL_DMA_IRQHandler(&self.hdma_usart3_tx);
+	HAL_DMA_IRQHandler(&SELF.hdma_usart3_tx);
 }
 
 void DMA1_Channel3_IRQHandler(void)
 {
-	HAL_DMA_IRQHandler(&self.hdma_usart3_rx);
+	HAL_DMA_IRQHandler(&SELF.hdma_usart3_rx);
 }
 
 err_t uart_tx(const uint8_t *p_buf, uint32_t size, uint32_t timeout_ticks, bool blocking)
@@ -159,37 +162,37 @@ err_t uart_tx(const uint8_t *p_buf, uint32_t size, uint32_t timeout_ticks, bool 
 	HAL_StatusTypeDef status;
 	err_t r = ERR_OK;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
-	if (xSemaphoreTake(self.tx_busy_semaphore, timeout_ticks) == pdFALSE)
+	if (xSemaphoreTake(SELF.tx_busy_semaphore, timeout_ticks) == pdFALSE)
 		return EUART_TX_SEMPH;
 
-	if (xSemaphoreTake(self.tx_done_semaphore, timeout_ticks) == pdFALSE) {
+	if (xSemaphoreTake(SELF.tx_done_semaphore, timeout_ticks) == pdFALSE) {
 		r = EUART_TX_SEMPH;
 		goto out;
 	}
 
 	/* Ugly const-to-non-const cast because the HAL is annoying. */
-	status = HAL_UART_Transmit_DMA(&self.uart_handle, (uint8_t*) p_buf, size);
+	status = HAL_UART_Transmit_DMA(&SELF.uart_handle, (uint8_t*) p_buf, size);
 	if (status != HAL_OK) {
 		r = HAL_ERROR_SET(status, EUART_TX);
 		goto out;
 	}
 
 	if (blocking) {
-		if (xSemaphoreTake(self.tx_done_semaphore, timeout_ticks) == pdFALSE) {
+		if (xSemaphoreTake(SELF.tx_done_semaphore, timeout_ticks) == pdFALSE) {
 			r = EUART_TX_TIMEOUT;
 			goto out;
 		}
-		xSemaphoreGive(self.tx_done_semaphore);
+		xSemaphoreGive(SELF.tx_done_semaphore);
 	}
 
 out:
-	xSemaphoreGive(self.tx_busy_semaphore);
+	xSemaphoreGive(SELF.tx_busy_semaphore);
 	return r;
 }
 
@@ -197,14 +200,14 @@ err_t uart_start_rx(QueueHandle_t queue)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
-	self.rx_queue_handle = queue;
-	status = HAL_UART_Receive_DMA(&self.uart_handle, (uint8_t*) self.rx_item.data, USB_FS_MAX_PACKET_SIZE);
+	SELF.rx_queue_handle = queue;
+	status = HAL_UART_Receive_DMA(&SELF.uart_handle, (uint8_t*) SELF.rx_item.data, USB_FS_MAX_PACKET_SIZE);
 	HAL_ERR_CHECK(status, EUART_RX);
 
 	return ERR_OK;
@@ -214,14 +217,14 @@ err_t uart_flush_rx(void)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
 	/* HAL_UART_AbortReceiveCpltCallback restarts DMA */
-	status = HAL_UART_AbortReceive_IT(&self.uart_handle);
+	status = HAL_UART_AbortReceive_IT(&SELF.uart_handle);
 	HAL_ERR_CHECK(status, EUART_FLUSH_RX);
 
 	return ERR_OK;
@@ -289,17 +292,17 @@ err_t uart_config_set(const struct uart_line_coding * const p_config)
 	HAL_StatusTypeDef status;
 	err_t r;
 	
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return EUART_DISABLED;
 
 	r = parse_config(&hal_config, p_config);
 	ERR_CHECK(r);
 
-	self.uart_handle.Init = hal_config;
-	status = UART_SetConfig(&self.uart_handle);
+	SELF.uart_handle.Init = hal_config;
+	status = UART_SetConfig(&SELF.uart_handle);
 	HAL_ERR_CHECK(status, EUART_HAL_INIT);
 
 	return ERR_OK;
@@ -309,10 +312,10 @@ err_t uart_enable(void)
 {
 	err_t r;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 	
-	if (self.enabled)
+	if (SELF.enabled)
 		return ERR_OK;
 
 	r = max14662_set_bit(MAX14662_AD_0_0, MAX14662_BIT_UART_RX, true);
@@ -321,7 +324,7 @@ err_t uart_enable(void)
 	r = max14662_set_bit(MAX14662_AD_0_0, MAX14662_BIT_UART_TX, true);
 	ERR_CHECK(r);
 
-	self.enabled = true;
+	SELF.enabled = true;
 
 	return ERR_OK;
 }
@@ -330,10 +333,10 @@ err_t uart_disable(void)
 {
 	err_t r;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUART_NO_INIT;
 
-	if (!self.enabled)
+	if (!SELF.enabled)
 		return ERR_OK;
 
 	r = max14662_set_bit(MAX14662_AD_0_0, MAX14662_BIT_UART_RX, false);
@@ -342,7 +345,7 @@ err_t uart_disable(void)
 	r = max14662_set_bit(MAX14662_AD_0_0, MAX14662_BIT_UART_TX, false);
 	ERR_CHECK(r);
 
-	self.enabled = false;
+	SELF.enabled = false;
 
 	return ERR_OK;
 }
@@ -351,31 +354,31 @@ err_t uart_init(void)
 {
 	HAL_StatusTypeDef status;
 
-	self.uart_handle.Instance = USART3;
-	self.uart_handle.Init.BaudRate = 115200;
-	self.uart_handle.Init.WordLength = UART_WORDLENGTH_8B;
-	self.uart_handle.Init.StopBits = UART_STOPBITS_1;
-	self.uart_handle.Init.Parity = UART_PARITY_NONE;
-	self.uart_handle.Init.Mode = UART_MODE_TX_RX;
-	self.uart_handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-	self.uart_handle.Init.OverSampling = UART_OVERSAMPLING_16;
-	self.uart_handle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
-	self.uart_handle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
+	SELF.uart_handle.Instance = USART3;
+	SELF.uart_handle.Init.BaudRate = 115200;
+	SELF.uart_handle.Init.WordLength = UART_WORDLENGTH_8B;
+	SELF.uart_handle.Init.StopBits = UART_STOPBITS_1;
+	SELF.uart_handle.Init.Parity = UART_PARITY_NONE;
+	SELF.uart_handle.Init.Mode = UART_MODE_TX_RX;
+	SELF.uart_handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+	SELF.uart_handle.Init.OverSampling = UART_OVERSAMPLING_16;
+	SELF.uart_handle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+	SELF.uart_handle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
 
-	status = HAL_UART_Init(&self.uart_handle);
+	status = HAL_UART_Init(&SELF.uart_handle);
 	HAL_ERR_CHECK(status, EUART_HAL_INIT);
 
-	self.tx_busy_semaphore = xSemaphoreCreateMutexStatic(&self.tx_busy_semaphore_buffer);
-	xSemaphoreGive(self.tx_busy_semaphore);
-	self.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.tx_done_semaphore_buffer);
-	xSemaphoreGive(self.tx_done_semaphore);
+	SELF.tx_busy_semaphore = xSemaphoreCreateMutexStatic(&SELF.tx_busy_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_busy_semaphore);
+	SELF.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.tx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_done_semaphore);
 
-	self.rx_busy_semaphore = xSemaphoreCreateMutexStatic(&self.rx_busy_semaphore_buffer);
-	xSemaphoreGive(self.rx_busy_semaphore);
-	self.rx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.rx_done_semaphore_buffer);
-	xSemaphoreGive(self.rx_done_semaphore);
+	SELF.rx_busy_semaphore = xSemaphoreCreateMutexStatic(&SELF.rx_busy_semaphore_buffer);
+	xSemaphoreGive(SELF.rx_busy_semaphore);
+	SELF.rx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.rx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.rx_done_semaphore);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32l4xx/usb.c
+++ b/platforms/stm32l4xx/usb.c
@@ -5,17 +5,20 @@
 #include "platform/usb/cdc.h"
 #include "platform/usb/hid.h"
 #include "platform/usb/usb.h"
+#include "usb/cdc_internal.h"
 #include "usb/core.h"
 #include "usb/ctlreq.h"
-#include "usb/cdc_internal.h"
 #include "usb/hid_internal.h"
+
+#define MODULE_NAME				STM32L4XX_USB
+#include "macros.h"
 
 static struct {
 	bool initialized;
 	USBD_HandleTypeDef usbd_handle;
 	PCD_HandleTypeDef pcd_handle;
 	char usb_serialnumber_string[17];
-} self;
+} SELF;
 
 static uint8_t *usb_desc_device(USBD_SpeedTypeDef speed, uint16_t *p_len);
 static uint8_t *usb_desc_langid(USBD_SpeedTypeDef speed, uint16_t *p_len);
@@ -306,7 +309,7 @@ static uint8_t *usb_desc_usr_str(USBD_HandleTypeDef *p_dev, uint8_t idx, uint16_
 		break;
 
 	case USBD_IDX_SERIAL_STR:
-		USBD_GetString((uint8_t *)self.usb_serialnumber_string, desc_str_buf, p_len);
+		USBD_GetString((uint8_t *)SELF.usb_serialnumber_string, desc_str_buf, p_len);
 		break;
 
 	case USBD_USER_STRING_CDC_IDX:
@@ -330,7 +333,7 @@ static uint8_t *usb_desc_usr_str(USBD_HandleTypeDef *p_dev, uint8_t idx, uint16_
 
 void USB_IRQHandler(void)
 {
-	HAL_PCD_IRQHandler(&self.pcd_handle);
+	HAL_PCD_IRQHandler(&SELF.pcd_handle);
 }
 
 err_t usb_init(void)
@@ -338,33 +341,33 @@ err_t usb_init(void)
 	HAL_StatusTypeDef status;
 	err_t r;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	sprintf(self.usb_serialnumber_string, "%08lx%08lx", HAL_GetUIDw0() + HAL_GetUIDw2(), HAL_GetUIDw1());
+	sprintf(SELF.usb_serialnumber_string, "%08lx%08lx", HAL_GetUIDw0() + HAL_GetUIDw2(), HAL_GetUIDw1());
 
-	r = pcd_init(&self.usbd_handle);
+	r = pcd_init(&SELF.usbd_handle);
 	ERR_CHECK(r);
 
-	status = USBD_Init(&self.usbd_handle, &self.pcd_handle, &desc_funcs);
+	status = USBD_Init(&SELF.usbd_handle, &SELF.pcd_handle, &desc_funcs);
 	HAL_ERR_CHECK(status, EUSB_USBD_INIT);
 
 	r = usb_hid_init(&((struct hid_init_data){
-		.p_usbd = &self.usbd_handle,
-		.p_pcd = &self.pcd_handle
+		.p_usbd = &SELF.usbd_handle,
+		.p_pcd = &SELF.pcd_handle
 	}));
 	ERR_CHECK(r);
 
 	r = usb_cdc_init(&((struct cdc_init_data){
-		.p_usbd = &self.usbd_handle,
-		.p_pcd = &self.pcd_handle
+		.p_usbd = &SELF.usbd_handle,
+		.p_pcd = &SELF.pcd_handle
 	}));
 	ERR_CHECK(r);
 
 	status = USBD_Start();
 	HAL_ERR_CHECK(status, EUSB_USBD_START);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32l4xx/usb.c
+++ b/platforms/stm32l4xx/usb.c
@@ -10,7 +10,7 @@
 #include "usb/ctlreq.h"
 #include "usb/hid_internal.h"
 
-#define MODULE_NAME				STM32L4XX_USB
+#define MODULE_NAME				stm32l4xx_usb
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32l4xx/usb/cdc.c
+++ b/platforms/stm32l4xx/usb/cdc.c
@@ -12,7 +12,7 @@
 #include "stm32l4xx_hal.h"
 #include "cdc_internal.h"
 
-#define MODULE_NAME				USB_CDC
+#define MODULE_NAME				usb_cdc
 #include "macros.h"
 
 #define CLASS_IDX		1

--- a/platforms/stm32l4xx/usb/cdc.c
+++ b/platforms/stm32l4xx/usb/cdc.c
@@ -12,6 +12,9 @@
 #include "stm32l4xx_hal.h"
 #include "cdc_internal.h"
 
+#define MODULE_NAME				USB_CDC
+#include "macros.h"
+
 #define CLASS_IDX		1
 #define QUEUE_LENGTH	10
 #define QUEUE_ITEM_SIZE	sizeof(struct usb_rx_queue_item)
@@ -30,7 +33,7 @@ static struct {
 	uint8_t rx_queue_storage[QUEUE_LENGTH * QUEUE_ITEM_SIZE];
 	SemaphoreHandle_t tx_done_semaphore;
 	StaticSemaphore_t tx_done_semaphore_buffer;
-} self;
+} SELF;
 
 static uint8_t cdc_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
 static uint8_t cdc_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
@@ -113,20 +116,20 @@ static void cdc_ctrl(uint8_t cmd, uint8_t *p_buf, uint16_t len)
 
 static uint8_t cdc_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Open(self.p_pcd, CDC_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
-	HAL_PCD_EP_Open(self.p_pcd, CDC_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
-	HAL_PCD_EP_Open(self.p_pcd, CDC_CMD_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
+	HAL_PCD_EP_Open(SELF.p_pcd, CDC_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
+	HAL_PCD_EP_Open(SELF.p_pcd, CDC_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_BULK);
+	HAL_PCD_EP_Open(SELF.p_pcd, CDC_CMD_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
 
-	HAL_PCD_EP_Receive(self.p_pcd, CDC_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_PCD_EP_Receive(SELF.p_pcd, CDC_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
 
 	return HAL_OK;
 }
 
 static uint8_t cdc_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Close(self.p_pcd, CDC_IN_EP);
-	HAL_PCD_EP_Close(self.p_pcd, CDC_OUT_EP);
-	HAL_PCD_EP_Close(self.p_pcd, CDC_CMD_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, CDC_IN_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, CDC_OUT_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, CDC_CMD_EP);
 
 	return HAL_OK;
 }
@@ -139,13 +142,13 @@ static uint8_t cdc_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 				(p_req->wIndex == USB_CDC_CTRL_INTERFACE_NO)) {
 			if (p_req->wLength) {
 				if (p_req->bmRequest.dir) {
-					cdc_ctrl(p_req->bRequest, (uint8_t *)self.ctrl_buf, p_req->wLength);
-					USBD_CtlSendData(p_dev, (uint8_t *)self.ctrl_buf, p_req->wLength);
+					cdc_ctrl(p_req->bRequest, (uint8_t *)SELF.ctrl_buf, p_req->wLength);
+					USBD_CtlSendData(p_dev, (uint8_t *)SELF.ctrl_buf, p_req->wLength);
 				} else {
-					self.ctrl_op_code = p_req->bRequest;
-					self.ctrl_len = p_req->wLength;
+					SELF.ctrl_op_code = p_req->bRequest;
+					SELF.ctrl_len = p_req->wLength;
 
-					USBD_CtlPrepareRx(p_dev, (uint8_t *)self.ctrl_buf, p_req->wLength);
+					USBD_CtlPrepareRx(p_dev, (uint8_t *)SELF.ctrl_buf, p_req->wLength);
 				}
 			} else {
 				cdc_ctrl(p_req->bRequest, (uint8_t *)p_req, 0);
@@ -156,11 +159,11 @@ static uint8_t cdc_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 	case USB_REQ_TYPE_STANDARD:
 		switch (p_req->bRequest) {
 		case USB_REQ_GET_INTERFACE:
-			USBD_CtlSendData(p_dev, &self.alt_interface, 1);
+			USBD_CtlSendData(p_dev, &SELF.alt_interface, 1);
 			break;
 
 		case USB_REQ_SET_INTERFACE:
-			self.alt_interface = p_req->wValue;
+			SELF.alt_interface = p_req->wValue;
 			break;
 		}
 
@@ -178,7 +181,7 @@ static uint8_t cdc_data_in(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != CDC_IN_EP)
 		return HAL_OK;
 
-	xSemaphoreGiveFromISR(self.tx_done_semaphore, &xHigherPriorityTaskWoken);
+	xSemaphoreGiveFromISR(SELF.tx_done_semaphore, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return HAL_OK;
@@ -192,10 +195,10 @@ static uint8_t cdc_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != CDC_OUT_EP)
 		return HAL_OK;
 
-	self.rx_buf.len = HAL_PCD_EP_GetRxCount(self.p_pcd, epnum);
-	status = HAL_PCD_EP_Receive(self.p_pcd, CDC_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	SELF.rx_buf.len = HAL_PCD_EP_GetRxCount(SELF.p_pcd, epnum);
+	status = HAL_PCD_EP_Receive(SELF.p_pcd, CDC_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
  
-	xQueueSendFromISR(self.rx_queue_handle, &self.rx_buf, &xHigherPriorityTaskWoken);
+	xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_buf, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return status;
@@ -203,25 +206,25 @@ static uint8_t cdc_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 
 static uint8_t cdc_ep0_rx_ready(USBD_HandleTypeDef *p_dev)
 {
-	if (self.ctrl_op_code == 0xFF)
+	if (SELF.ctrl_op_code == 0xFF)
 		return HAL_OK;
 
-	cdc_ctrl(self.ctrl_op_code, (uint8_t *)self.ctrl_buf, self.ctrl_len);
+	cdc_ctrl(SELF.ctrl_op_code, (uint8_t *)SELF.ctrl_buf, SELF.ctrl_len);
 
-	self.ctrl_op_code = 0xFF;
+	SELF.ctrl_op_code = 0xFF;
 
 	return HAL_OK;
 }
 
 err_t usb_cdc_rx(struct usb_rx_queue_item *p_rx_queue_item, uint32_t timeout_ticks)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_CDC_NO_INIT;
 
 	if (!p_rx_queue_item)
 		return EUSB_CDC_INVALID_ARG;
 
-	if (xQueueReceive(self.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
+	if (xQueueReceive(SELF.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
 		return EUSB_CDC_RX_TIMEOUT;
 
 	return ERR_OK;
@@ -231,15 +234,15 @@ err_t usb_cdc_tx(uint8_t *p_buf, uint16_t len)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_CDC_NO_INIT;
 
-	if (self.p_usbd->dev_state != USBD_STATE_CONFIGURED)
+	if (SELF.p_usbd->dev_state != USBD_STATE_CONFIGURED)
 		return EUSB_CDC_NOT_READY;
 
-	xSemaphoreTake(self.tx_done_semaphore, portMAX_DELAY);
+	xSemaphoreTake(SELF.tx_done_semaphore, portMAX_DELAY);
 
-	status = HAL_PCD_EP_Transmit(self.p_pcd, CDC_IN_EP, p_buf, len);
+	status = HAL_PCD_EP_Transmit(SELF.p_pcd, CDC_IN_EP, p_buf, len);
 	HAL_ERR_CHECK(status, EUSB_CDC_TRANSMIT);
 
 	return ERR_OK;
@@ -249,29 +252,29 @@ err_t usb_cdc_init(const struct cdc_init_data *p_data)
 {
 	HAL_StatusTypeDef status;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.p_usbd = p_data->p_usbd;
-	self.p_pcd = p_data->p_pcd;
+	SELF.p_usbd = p_data->p_usbd;
+	SELF.p_pcd = p_data->p_pcd;
 
-	HAL_PCDEx_PMAConfig(self.p_pcd, CDC_CMD_EP, PCD_SNG_BUF, USB_PMA_BASE + 2 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, CDC_CMD_EP, PCD_SNG_BUF, USB_PMA_BASE + 2 * USB_FS_MAX_PACKET_SIZE);
 
-	HAL_PCDEx_PMAConfig(self.p_pcd, CDC_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 4 * USB_FS_MAX_PACKET_SIZE);
-	HAL_PCDEx_PMAConfig(self.p_pcd, CDC_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 5 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, CDC_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 4 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, CDC_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 5 * USB_FS_MAX_PACKET_SIZE);
 
-	status = USBD_RegisterClass(self.p_usbd, CLASS_IDX, &cdc_class_def);
+	status = USBD_RegisterClass(SELF.p_usbd, CLASS_IDX, &cdc_class_def);
 	HAL_ERR_CHECK(status, EUSB_CDC_REG_CLASS);
 
-	self.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
+	SELF.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
 		QUEUE_ITEM_SIZE,
-		self.rx_queue_storage,
-		&self.rx_queue);
+		SELF.rx_queue_storage,
+		&SELF.rx_queue);
 
-	self.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.tx_done_semaphore_buffer);
-	xSemaphoreGive(self.tx_done_semaphore);
+	SELF.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.tx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_done_semaphore);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }

--- a/platforms/stm32l4xx/usb/core.c
+++ b/platforms/stm32l4xx/usb/core.c
@@ -28,7 +28,7 @@
 #include "stm32l4xx_hal.h"
 #include "usb/core.h"
 
-#define MODULE_NAME				USB_CORE
+#define MODULE_NAME				usb_core
 #include "macros.h"
 
 static struct {

--- a/platforms/stm32l4xx/usb/core.c
+++ b/platforms/stm32l4xx/usb/core.c
@@ -25,12 +25,15 @@
   ******************************************************************************
   */
 
-#include "usb/core.h"
 #include "stm32l4xx_hal.h"
+#include "usb/core.h"
+
+#define MODULE_NAME				USB_CORE
+#include "macros.h"
 
 static struct {
 	PCD_HandleTypeDef *p_pcd;
-} self;
+} SELF;
 
 HAL_StatusTypeDef USBD_Init(USBD_HandleTypeDef *p_dev, PCD_HandleTypeDef *p_pcd, USBD_DescriptorsTypeDef *p_desc)
 {
@@ -43,16 +46,16 @@ HAL_StatusTypeDef USBD_Init(USBD_HandleTypeDef *p_dev, PCD_HandleTypeDef *p_pcd,
 	/* Enable USB power on Pwrctrl CR2 register. */
 	HAL_PWREx_EnableVddUSB();
 
-	self.p_pcd = p_pcd;
-	self.p_pcd->Instance = USB;
-	self.p_pcd->Init.dev_endpoints = USBD_MAX_NUM_ENDPOINTS;
-	self.p_pcd->Init.speed = PCD_SPEED_FULL;
-	self.p_pcd->Init.ep0_mps = DEP0CTL_MPS_64;
-	self.p_pcd->Init.phy_itface = PCD_PHY_EMBEDDED;
-	self.p_pcd->Init.Sof_enable = DISABLE;
-	self.p_pcd->Init.low_power_enable = DISABLE;
-	self.p_pcd->Init.lpm_enable = DISABLE;
-	self.p_pcd->Init.battery_charging_enable = DISABLE;
+	SELF.p_pcd = p_pcd;
+	SELF.p_pcd->Instance = USB;
+	SELF.p_pcd->Init.dev_endpoints = USBD_MAX_NUM_ENDPOINTS;
+	SELF.p_pcd->Init.speed = PCD_SPEED_FULL;
+	SELF.p_pcd->Init.ep0_mps = DEP0CTL_MPS_64;
+	SELF.p_pcd->Init.phy_itface = PCD_PHY_EMBEDDED;
+	SELF.p_pcd->Init.Sof_enable = DISABLE;
+	SELF.p_pcd->Init.low_power_enable = DISABLE;
+	SELF.p_pcd->Init.lpm_enable = DISABLE;
+	SELF.p_pcd->Init.battery_charging_enable = DISABLE;
 
 	if (HAL_PCD_Init(p_pcd) != HAL_OK)
 		return HAL_ERROR;
@@ -70,7 +73,7 @@ HAL_StatusTypeDef USBD_DeInit(USBD_HandleTypeDef *p_dev)
 
 	USBD_Stop(p_dev);
 
-	return HAL_PCD_DeInit(self.p_pcd);
+	return HAL_PCD_DeInit(SELF.p_pcd);
 }
 
 HAL_StatusTypeDef USBD_RegisterClass(USBD_HandleTypeDef *p_dev, uint8_t idx, USBD_ClassTypeDef *p_class)
@@ -86,7 +89,7 @@ HAL_StatusTypeDef USBD_RegisterClass(USBD_HandleTypeDef *p_dev, uint8_t idx, USB
 
 HAL_StatusTypeDef USBD_Start(void)
 {
-	return HAL_PCD_Start(self.p_pcd);
+	return HAL_PCD_Start(SELF.p_pcd);
 }
 
 HAL_StatusTypeDef USBD_Stop(USBD_HandleTypeDef *p_dev)
@@ -95,7 +98,7 @@ HAL_StatusTypeDef USBD_Stop(USBD_HandleTypeDef *p_dev)
 	for (int i = 0; i < USBD_MAX_NUM_CLASSES; ++i)
 		p_dev->pClasses[i]->DeInit(p_dev, p_dev->dev_config);
 
-	return HAL_PCD_Stop(self.p_pcd);
+	return HAL_PCD_Stop(SELF.p_pcd);
 }
 
 HAL_StatusTypeDef USBD_SetClassConfig(USBD_HandleTypeDef *p_dev, uint8_t idx, uint8_t cfgidx)
@@ -124,7 +127,7 @@ HAL_StatusTypeDef USBD_CtlSendData(USBD_HandleTypeDef *p_dev, uint8_t *p_buf, ui
 	p_dev->ep_in[0].rem_length   = len;
 
 	/* Start the transfer */
-	return HAL_PCD_EP_Transmit(self.p_pcd, 0x00, p_buf, len);
+	return HAL_PCD_EP_Transmit(SELF.p_pcd, 0x00, p_buf, len);
 }
 
 HAL_StatusTypeDef USBD_CtlPrepareRx(USBD_HandleTypeDef *p_dev, uint8_t *p_buf, uint16_t len)
@@ -135,7 +138,7 @@ HAL_StatusTypeDef USBD_CtlPrepareRx(USBD_HandleTypeDef *p_dev, uint8_t *p_buf, u
 	p_dev->ep_out[0].rem_length   = len;
 
 	/* Start the transfer */
-	return HAL_PCD_EP_Receive(self.p_pcd, 0x00, p_buf, len);
+	return HAL_PCD_EP_Receive(SELF.p_pcd, 0x00, p_buf, len);
 }
 
 HAL_StatusTypeDef USBD_CtlSendStatus(USBD_HandleTypeDef *p_dev)
@@ -144,13 +147,13 @@ HAL_StatusTypeDef USBD_CtlSendStatus(USBD_HandleTypeDef *p_dev)
 	p_dev->ep0_state = USBD_EP0_STATUS_IN;
 
 	/* Start the transfer */
-	return HAL_PCD_EP_Transmit(self.p_pcd, 0x00, NULL, 0);
+	return HAL_PCD_EP_Transmit(SELF.p_pcd, 0x00, NULL, 0);
 }
 
 uint8_t USBD_LL_IsStallEP(USBD_HandleTypeDef *p_dev, uint8_t ep_addr)
 {
 	if((ep_addr & 0x80) == 0x80)
-		return self.p_pcd->IN_ep[ep_addr & 0x7F].is_stall;
+		return SELF.p_pcd->IN_ep[ep_addr & 0x7F].is_stall;
 
-	return self.p_pcd->OUT_ep[ep_addr & 0x7F].is_stall;
+	return SELF.p_pcd->OUT_ep[ep_addr & 0x7F].is_stall;
 }

--- a/platforms/stm32l4xx/usb/hid.c
+++ b/platforms/stm32l4xx/usb/hid.c
@@ -11,7 +11,7 @@
 #include "stm32l4xx_hal.h"
 #include "hid_internal.h"
 
-#define MODULE_NAME		USB_HID
+#define MODULE_NAME		usb_hid
 #include "macros.h"
 
 #define CLASS_IDX		0

--- a/platforms/stm32l4xx/usb/hid.c
+++ b/platforms/stm32l4xx/usb/hid.c
@@ -11,6 +11,9 @@
 #include "stm32l4xx_hal.h"
 #include "hid_internal.h"
 
+#define MODULE_NAME		USB_HID
+#include "macros.h"
+
 #define CLASS_IDX		0
 #define QUEUE_LENGTH	10
 #define QUEUE_ITEM_SIZE	sizeof(struct usb_rx_queue_item)
@@ -29,7 +32,7 @@ static struct {
 	uint8_t rx_queue_storage[QUEUE_LENGTH * QUEUE_ITEM_SIZE];
 	SemaphoreHandle_t tx_done_semaphore;
 	StaticSemaphore_t tx_done_semaphore_buffer;
-} self;
+} SELF;
 
 static uint8_t hid_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
 static uint8_t hid_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx);
@@ -88,18 +91,18 @@ static uint8_t desc_hid[] = {
 
 static uint8_t hid_init(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Open(self.p_pcd, HID_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
-	HAL_PCD_EP_Open(self.p_pcd, HID_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
+	HAL_PCD_EP_Open(SELF.p_pcd, HID_IN_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
+	HAL_PCD_EP_Open(SELF.p_pcd, HID_OUT_EP, USB_FS_MAX_PACKET_SIZE, USBD_EP_TYPE_INTR);
 
-	HAL_PCD_EP_Receive(self.p_pcd, HID_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	HAL_PCD_EP_Receive(SELF.p_pcd, HID_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
 
 	return HAL_OK;
 }
 
 static uint8_t hid_deinit(USBD_HandleTypeDef *p_dev, uint8_t cfgidx)
 {
-	HAL_PCD_EP_Close(self.p_pcd, HID_IN_EP);
-	HAL_PCD_EP_Close(self.p_pcd, HID_OUT_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, HID_IN_EP);
+	HAL_PCD_EP_Close(SELF.p_pcd, HID_OUT_EP);
 
 	return HAL_OK;
 }
@@ -115,28 +118,28 @@ static uint8_t hid_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 				(p_req->wIndex == USB_HID_INTERFACE_NO)) {
 			switch (p_req->bRequest) {
 			case HID_REQ_SET_PROTOCOL:
-				self.protocol = (uint8_t)(p_req->wValue);
+				SELF.protocol = (uint8_t)(p_req->wValue);
 				break;
 
 			case HID_REQ_GET_PROTOCOL:
-				USBD_CtlSendData(p_dev, (uint8_t *)&self.protocol, 1);
+				USBD_CtlSendData(p_dev, (uint8_t *)&SELF.protocol, 1);
 				break;
 
 			case HID_REQ_SET_IDLE:
-				self.idle_state = (uint8_t)(p_req->wValue >> 8);
+				SELF.idle_state = (uint8_t)(p_req->wValue >> 8);
 				break;
 
 			case HID_REQ_GET_IDLE:
-				USBD_CtlSendData(p_dev, (uint8_t *)&self.idle_state, 1);
+				USBD_CtlSendData(p_dev, (uint8_t *)&SELF.idle_state, 1);
 				break;
 
 			case HID_REQ_SET_REPORT:
-				self.report_available = true;
-				USBD_CtlPrepareRx(p_dev, self.rx_buf.data, p_req->wLength);
+				SELF.report_available = true;
+				USBD_CtlPrepareRx(p_dev, SELF.rx_buf.data, p_req->wLength);
 				break;
 
 			default:
-				USBD_CtlError(self.p_pcd);
+				USBD_CtlError(SELF.p_pcd);
 				return HAL_ERROR;
 			}
 		}
@@ -157,11 +160,11 @@ static uint8_t hid_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 			break;
 
 		case USB_REQ_GET_INTERFACE:
-			USBD_CtlSendData(p_dev, (uint8_t *)&self.alt_interface, 1);
+			USBD_CtlSendData(p_dev, (uint8_t *)&SELF.alt_interface, 1);
 			break;
 
 		case USB_REQ_SET_INTERFACE:
-			self.alt_interface = (uint8_t)(p_req->wValue);
+			SELF.alt_interface = (uint8_t)(p_req->wValue);
 			break;
 		}
 	}
@@ -171,10 +174,10 @@ static uint8_t hid_setup(USBD_HandleTypeDef *p_dev, USBD_SetupReqTypedef *p_req)
 
 static uint8_t hid_ep0_rx_ready(USBD_HandleTypeDef *p_dev)
 {
-	if (!self.report_available)
+	if (!SELF.report_available)
 		return HAL_OK;
 
-	self.report_available = false;
+	SELF.report_available = false;
 
 	return HAL_OK;
 }
@@ -186,7 +189,7 @@ static uint8_t hid_data_in(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != HID_IN_EP)
 		return HAL_OK;
 
-	xSemaphoreGiveFromISR(self.tx_done_semaphore, &xHigherPriorityTaskWoken);
+	xSemaphoreGiveFromISR(SELF.tx_done_semaphore, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return HAL_OK;
@@ -200,10 +203,10 @@ static uint8_t hid_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 	if (epnum != HID_OUT_EP)
 		return HAL_OK;
 
-	self.rx_buf.len = HAL_PCD_EP_GetRxCount(self.p_pcd, epnum);
-	status = HAL_PCD_EP_Receive(self.p_pcd, HID_OUT_EP, self.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
+	SELF.rx_buf.len = HAL_PCD_EP_GetRxCount(SELF.p_pcd, epnum);
+	status = HAL_PCD_EP_Receive(SELF.p_pcd, HID_OUT_EP, SELF.rx_buf.data, USB_FS_MAX_PACKET_SIZE);
 
-	xQueueSendFromISR(self.rx_queue_handle, &self.rx_buf, &xHigherPriorityTaskWoken);
+	xQueueSendFromISR(SELF.rx_queue_handle, &SELF.rx_buf, &xHigherPriorityTaskWoken);
 	portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
 	return status;
@@ -211,13 +214,13 @@ static uint8_t hid_data_out(USBD_HandleTypeDef *p_dev, uint8_t epnum)
 
 err_t usb_hid_recv(struct usb_rx_queue_item *p_rx_queue_item, uint32_t timeout_ticks)
 {
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_HID_NO_INIT;
 
 	if (!p_rx_queue_item)
 		return EUSB_HID_INVALID_ARG;
 
-	if (xQueueReceive(self.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
+	if (xQueueReceive(SELF.rx_queue_handle, p_rx_queue_item, timeout_ticks) == pdFALSE)
 		return EUSB_HID_RECV_TIMEOUT;
 
 	return ERR_OK;
@@ -227,15 +230,15 @@ err_t usb_hid_send(uint8_t *p_buf, uint16_t len)
 {
 	HAL_StatusTypeDef status;
 
-	if (!self.initialized)
+	if (!SELF.initialized)
 		return EUSB_HID_NO_INIT;
 
-	if (self.p_usbd->dev_state != USBD_STATE_CONFIGURED)
+	if (SELF.p_usbd->dev_state != USBD_STATE_CONFIGURED)
 		return EUSB_HID_NOT_READY;
 
-	xSemaphoreTake(self.tx_done_semaphore, portMAX_DELAY);
+	xSemaphoreTake(SELF.tx_done_semaphore, portMAX_DELAY);
 
-	status = HAL_PCD_EP_Transmit(self.p_pcd, HID_IN_EP, p_buf, len);
+	status = HAL_PCD_EP_Transmit(SELF.p_pcd, HID_IN_EP, p_buf, len);
 	HAL_ERR_CHECK(status, EUSB_HID_TRANSMIT);
 
 	return ERR_OK;
@@ -245,27 +248,27 @@ err_t usb_hid_init(const struct hid_init_data *p_data)
 {
 	HAL_StatusTypeDef status;
 
-	if (self.initialized)
+	if (SELF.initialized)
 		return ERR_OK;
 
-	self.p_usbd = p_data->p_usbd;
-	self.p_pcd = p_data->p_pcd;
+	SELF.p_usbd = p_data->p_usbd;
+	SELF.p_pcd = p_data->p_pcd;
 
-	HAL_PCDEx_PMAConfig(self.p_pcd, HID_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 3 * USB_FS_MAX_PACKET_SIZE);
-	HAL_PCDEx_PMAConfig(self.p_pcd, HID_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 6 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, HID_OUT_EP, PCD_SNG_BUF, USB_PMA_BASE + 3 * USB_FS_MAX_PACKET_SIZE);
+	HAL_PCDEx_PMAConfig(SELF.p_pcd, HID_IN_EP,  PCD_SNG_BUF, USB_PMA_BASE + 6 * USB_FS_MAX_PACKET_SIZE);
 
-	status = USBD_RegisterClass(self.p_usbd, CLASS_IDX, &hid_class_def);
+	status = USBD_RegisterClass(SELF.p_usbd, CLASS_IDX, &hid_class_def);
 	HAL_ERR_CHECK(status, EUSB_HID_REG_CLASS);
 
-	self.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
+	SELF.rx_queue_handle = xQueueCreateStatic(QUEUE_LENGTH,
 		QUEUE_ITEM_SIZE,
-		self.rx_queue_storage,
-		&self.rx_queue);
+		SELF.rx_queue_storage,
+		&SELF.rx_queue);
 
-	self.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&self.tx_done_semaphore_buffer);
-	xSemaphoreGive(self.tx_done_semaphore);
+	SELF.tx_done_semaphore = xSemaphoreCreateBinaryStatic(&SELF.tx_done_semaphore_buffer);
+	xSemaphoreGive(SELF.tx_done_semaphore);
 
-	self.initialized = true;
+	SELF.initialized = true;
 
 	return ERR_OK;
 }


### PR DESCRIPTION
Add macro that concatenates a module name with `self` so we get unique struct names, e.g. `usb_hid_self`, that can be used for debugging and size statistics.